### PR TITLE
Changes made to follow Go coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@
 
 This package contains the commands which Lime will use. A command is anything that peforms some action in the editor(like move lines, save file, open file etc).
 
-Lime is designed with the goal of having a clear frontend and backend separation to allow and hopefully simplify the creation of multiple frontend versions.
-
-The Lime Architecture is simple:
-1. `backend`: Contain all the code that defines the text editor. The Windows, Folders, Files etc.
-2. `front end`: The UI part which will import the backend. When you click on any menu item, the _command_ for that item will be executed via the _Run_ method which you declare. The menubar, the Editor where we will type text into etc
-3. `commands`: Utilities which will execute whenever you interact with the UI. 
-
-
 ##Brief overview of Commands
 
 You first build a type of the command which you are writing. 
@@ -33,6 +25,13 @@ Each command has a `Run` method which is executed when the command is invoked. P
         //Do something here
     }
 
+Commands need to be registered with the backend via the init function.
+
+    func init() {
+        register([]backend.Command{
+            &SwapLineUp{},
+        })
+    }
 #Imlementing custom commands
 
 If you are interested in implementing your own command, look into the [Implementing commands wiki page](https://github.com/limetext/lime/wiki/Implementing-commands).

--- a/README.md
+++ b/README.md
@@ -4,4 +4,41 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/limetext/commands)](https://goreportcard.com/report/github.com/limetext/commands)
 [![GoDoc](https://godoc.org/github.com/limetext/commands?status.svg)](https://godoc.org/github.com/limetext/commands)
 
-Lime commands
+This package contains the commands which Lime will use. A command is anything that peforms some action in the editor(like move lines, save file, open file etc).
+
+Lime is designed with the goal of having a clear frontend and backend separation to allow and hopefully simplify the creation of multiple frontend versions.
+
+The Lime Architecture is simple:
+1. `backend`: Contain all the code that defines the text editor. The Windows, Folders, Files etc.
+2. `front end`: The UI part which will import the backend. When you click on any menu item, the _command_ for that item will be executed via the _Run_ method which you declare. The menubar, the Editor where we will type text into etc
+3. `commands`: Utilities which will execute whenever you interact with the UI. 
+
+
+##Brief overview of Commands
+
+You first build a type of the command which you are writing. 
+
+    type (
+        // JoinLines removes every new line in the
+        // selections and the first new line after
+        JoinLines struct {
+            backend.DefaultCommand
+        }
+    )
+
+Each command has a `Run` method which is executed when the command is invoked. Please note that the command needs to be invoked by the UI for it to work.
+
+    //Run executes the SwapLineUp command
+    func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
+        //Do something here
+    }
+
+#Imlementing custom commands
+
+If you are interested in implementing your own command, look into the [Implementing commands wiki page](https://github.com/limetext/lime/wiki/Implementing-commands).
+
+
+# Other references
+
+* [Lime Command interface Api Documentation](http://godoc.org/github.com/limetext/backend#Command)
+* Sublime Text 3 unofficial (and [open source](https://github.com/guillermooo/sublime-undocs/)!) [Command documentation](http://docs.sublimetext.info/en/sublime-text-3/extensibility/commands.html)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package contains commands made accessible to frontends and plugins. They co
 
 #Goals
 
-The Goal is to implement all the commands present in Sublimetext.
+The goal for release 1.0 is to implement all Sublime Text commands.
 
 ##Brief overview of Commands
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Commands need to be registered with the backend via the init function.
         })
     }
 
-#Imlementing custom commands
+#Implementing custom commands
 
 If you are interested in implementing your own command, look into the [Implementing commands wiki page](https://github.com/limetext/lime/wiki/Implementing-commands).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/limetext/commands)](https://goreportcard.com/report/github.com/limetext/commands)
 [![GoDoc](https://godoc.org/github.com/limetext/commands?status.svg)](https://godoc.org/github.com/limetext/commands)
 
-This package contains the commands which Lime will use. A command is anything that peforms some action in the editor(like move lines, save file, open file etc).
+This package contains commands made accessible to frontends and plugins. They come in three flavours: [`ApplicationCommand`](https://godoc.org/github.com/limetext/backend#ApplicationCommand)s, [`WindowCommand`](https://godoc.org/github.com/limetext/backend#WindowCommand)s, and [`TextCommand`](https://godoc.org/github.com/limetext/backend#TextCommand)s."
 
 ##Brief overview of Commands
 
@@ -18,10 +18,10 @@ You first build a type of the command which you are writing.
         }
     )
 
-Each command has a `Run` method which is executed when the command is invoked. Please note that the command needs to be invoked by the UI for it to work.
+Each command has a `Run` method which is executed when the command is invoked. Please note that the command needs to be invoked by the frontend for it to work.
 
-    //Run executes the SwapLineUp command
-    func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
+    //Run executes the DoSomething command
+    func (c *DoSomething) Run(v *backend.View, e *backend.Edit) error {
         //Do something here
     }
 
@@ -29,9 +29,10 @@ Commands need to be registered with the backend via the init function.
 
     func init() {
         register([]backend.Command{
-            &SwapLineUp{},
+            &DoSomething{},
         })
     }
+
 #Imlementing custom commands
 
 If you are interested in implementing your own command, look into the [Implementing commands wiki page](https://github.com/limetext/lime/wiki/Implementing-commands).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 This package contains commands made accessible to frontends and plugins. They come in three flavours: [`ApplicationCommand`](https://godoc.org/github.com/limetext/backend#ApplicationCommand)s, [`WindowCommand`](https://godoc.org/github.com/limetext/backend#WindowCommand)s, and [`TextCommand`](https://godoc.org/github.com/limetext/backend#TextCommand)s."
 
+#Goals
+
+The Goal is to implement all the commands present in Sublimetext.
+
 ##Brief overview of Commands
 
 You first build a type of the command which you are writing. 
@@ -18,7 +22,7 @@ You first build a type of the command which you are writing.
         }
     )
 
-Each command has a `Run` method which is executed when the command is invoked. Please note that the command needs to be invoked by the frontend for it to work.
+Each command has a `Run` method which is executed when the command is invoked.
 
     //Run executes the DoSomething command
     func (c *DoSomething) Run(v *backend.View, e *backend.Edit) error {

--- a/case.go
+++ b/case.go
@@ -46,7 +46,7 @@ type (
 	}
 )
 
-//Run will execute the TitleCase command
+// Run will execute the TitleCase command
 func (c *TitleCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -59,7 +59,7 @@ func (c *TitleCase) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the SwapCase command
+// Run will execute the SwapCase command
 func (c *SwapCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -81,7 +81,7 @@ func (c *SwapCase) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the UpperCase command
+// Run will execute the UpperCase command
 func (c *UpperCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -94,7 +94,7 @@ func (c *UpperCase) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the LowerCase command
+// Run will execute the LowerCase command
 func (c *LowerCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {

--- a/case.go
+++ b/case.go
@@ -8,45 +8,46 @@ import (
 	"strings"
 	"unicode"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
-	// The TitleCaseCommand transforms all selections
+	// TitleCase Command transforms all selections
 	// to be in Title Case.  For instance, the text:
 	// "this is some sample text"
 	// turns in to:
 	// "This Is Some Sample Text"
 	TitleCase struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The SwapCaseCommand transforms all selections
+	// SwapCase Command transforms all selections
 	// so that each character in the selection
 	// is the opposite case.  For example, the text:
 	// "Hello, World!"
 	// turns in to:
 	// "hELLO, wORLD!"
 	SwapCase struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The UpperCaseCommand transforms all selections
+	// UpperCase Command transforms all selections
 	// so that each character in the selection
 	// is in its upper case equivalent (if any.)
 	UpperCase struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The LowerCaseCommand transforms all selections
+	// LowerCase Command transforms all selections
 	// so that each character in the selection
 	// is in its lower case equivalent
 	LowerCase struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *TitleCase) Run(v *View, e *Edit) error {
+//Run will execute the TitleCase command
+func (c *TitleCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
@@ -58,7 +59,8 @@ func (c *TitleCase) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SwapCase) Run(v *View, e *Edit) error {
+//Run will execute the SwapCase command
+func (c *SwapCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
@@ -79,7 +81,8 @@ func (c *SwapCase) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *UpperCase) Run(v *View, e *Edit) error {
+//Run will execute the UpperCase command
+func (c *UpperCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
@@ -91,7 +94,8 @@ func (c *UpperCase) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *LowerCase) Run(v *View, e *Edit) error {
+//Run will execute the LowerCase command
+func (c *LowerCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
@@ -104,7 +108,7 @@ func (c *LowerCase) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&TitleCase{},
 		&SwapCase{},
 		&UpperCase{},

--- a/case.go
+++ b/case.go
@@ -16,7 +16,7 @@ type (
 	// to be in Title Case.  For instance, the text:
 	// "this is some sample text"
 	// turns in to:
-	// "This Is Some Sample Text"
+	// "This Is Some Sample Text".
 	TitleCase struct {
 		backend.DefaultCommand
 	}
@@ -26,7 +26,7 @@ type (
 	// is the opposite case.  For example, the text:
 	// "Hello, World!"
 	// turns in to:
-	// "hELLO, wORLD!"
+	// "hELLO, wORLD!".
 	SwapCase struct {
 		backend.DefaultCommand
 	}
@@ -40,13 +40,13 @@ type (
 
 	// LowerCase Command transforms all selections
 	// so that each character in the selection
-	// is in its lower case equivalent
+	// is in its lower case equivalent.
 	LowerCase struct {
 		backend.DefaultCommand
 	}
 )
 
-// Run will execute the TitleCase command
+// Run executes the TitleCase command.
 func (c *TitleCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -59,7 +59,7 @@ func (c *TitleCase) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the SwapCase command
+// Run executes the SwapCase command.
 func (c *SwapCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -81,7 +81,7 @@ func (c *SwapCase) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the UpperCase command
+// Run executes the UpperCase command.
 func (c *UpperCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -94,7 +94,7 @@ func (c *UpperCase) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the LowerCase command
+// Run executes the LowerCase command.
 func (c *LowerCase) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {

--- a/case_test.go
+++ b/case_test.go
@@ -7,18 +7,18 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type caseTest struct {
-	in_region []Region
-	in        string
-	exp       string
+	inRegion []text.Region
+	in       string
+	exp      string
 }
 
 func runCaseTest(command string, testsuite *[]caseTest, t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -34,13 +34,13 @@ func runCaseTest(command string, testsuite *[]caseTest, t *testing.T) {
 		v.EndEdit(e)
 
 		v.Sel().Clear()
-		if test.in_region != nil {
-			for _, r := range test.in_region {
+		if test.inRegion != nil {
+			for _, r := range test.inRegion {
 				v.Sel().Add(r)
 			}
 		}
 		ed.CommandHandler().RunTextCommand(v, command, nil)
-		sr := v.Substr(Region{0, v.Size()})
+		sr := v.Substr(text.Region{0, v.Size()})
 		if sr != test.exp {
 			t.Errorf("%s test %d failed: %v, %+v", command, i, sr, test)
 		}
@@ -54,14 +54,14 @@ func TestTitleCase(t *testing.T) {
 			// Please note the bizarre  capitalization of the first L in he'Ll...  This is due to a bug in go's strings
 			// library.  I'm going to try to get them to fix it...  If not, maybe we'll have
 			// to write our own Title Casing function.
-			[]Region{{24, 51}},
+			[]text.Region{{24, 51}},
 
 			"Give a man a match, and he'll be warm for a minute, but set him on fire, and he'll be warm for the rest of his life.",
 			"Give a man a match, and He'Ll Be Warm For A Minute, but set him on fire, and he'll be warm for the rest of his life.",
 		},
 		/*multiple selection*/
 		{
-			[]Region{{0, 17}, {52, 71}},
+			[]text.Region{{0, 17}, {52, 71}},
 
 			"Give a man a match, and he'll be warm for a minute, but set him on fire, and he'll be warm for the rest of his life.",
 			"Give A Man A Match, and he'll be warm for a minute, But Set Him On Fire, and he'll be warm for the rest of his life.",
@@ -75,14 +75,14 @@ func TestTitleCase(t *testing.T) {
 		},
 		/*unicode*/
 		{
-			[]Region{{0, 12}},
+			[]text.Region{{0, 12}},
 
 			"ничего себе!",
 			"Ничего Себе!",
 		},
 		/*asian characters*/
 		{
-			[]Region{{0, 9}},
+			[]text.Region{{0, 9}},
 
 			"千里之行﹐始于足下",
 			"千里之行﹐始于足下",
@@ -95,19 +95,19 @@ func TestTitleCase(t *testing.T) {
 func TestSwapCase(t *testing.T) {
 	tests := []caseTest{
 		{
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 
 			"",
 			"",
 		},
 		{
-			[]Region{{0, 13}},
+			[]text.Region{{0, 13}},
 
 			"Hello, World!",
 			"hELLO, wORLD!",
 		},
 		{
-			[]Region{{0, 11}},
+			[]text.Region{{0, 11}},
 
 			"ПрИвЕт, МиР",
 			"пРиВеТ, мИр",
@@ -121,14 +121,14 @@ func TestUpperCase(t *testing.T) {
 	tests := []caseTest{
 		/*single selection*/
 		{
-			[]Region{{0, 76}},
+			[]text.Region{{0, 76}},
 
 			"Try not to become a man of success, but rather try to become a man of value.",
 			"TRY NOT TO BECOME A MAN OF SUCCESS, BUT RATHER TRY TO BECOME A MAN OF VALUE.",
 		},
 		/*multiple selection*/
 		{
-			[]Region{{0, 20}, {74, 76}},
+			[]text.Region{{0, 20}, {74, 76}},
 
 			"Try not to become a man of success, but rather try to become a man of value.",
 			"TRY NOT TO BECOME A man of success, but rather try to become a man of valuE.",
@@ -142,14 +142,14 @@ func TestUpperCase(t *testing.T) {
 		},
 		/*unicode*/
 		{
-			[]Region{{0, 74}},
+			[]text.Region{{0, 74}},
 
 			"чем больше законов и постановлений, тем больше разбойников и преступлений!",
 			"ЧЕМ БОЛЬШЕ ЗАКОНОВ И ПОСТАНОВЛЕНИЙ, ТЕМ БОЛЬШЕ РАЗБОЙНИКОВ И ПРЕСТУПЛЕНИЙ!",
 		},
 		/*asian characters*/
 		{
-			[]Region{{0, 9}},
+			[]text.Region{{0, 9}},
 
 			"千里之行﹐始于足下",
 			"千里之行﹐始于足下",
@@ -163,14 +163,14 @@ func TestLowerCase(t *testing.T) {
 	tests := []caseTest{
 		/*single selection*/
 		{
-			[]Region{{0, 76}},
+			[]text.Region{{0, 76}},
 
 			"TRY NOT TO BECOME A MAN OF SUCCESS, BUT RATHER TRY TO BECOME A MAN OF VALUE.",
 			"try not to become a man of success, but rather try to become a man of value.",
 		},
 		/*multiple selection*/
 		{
-			[]Region{{0, 20}, {74, 76}},
+			[]text.Region{{0, 20}, {74, 76}},
 
 			"TRY NOT TO BECOME A MAN OF SUCCESS, BUT RATHER TRY TO BECOME A MAN OF VALUE.",
 			"try not to become a MAN OF SUCCESS, BUT RATHER TRY TO BECOME A MAN OF VALUe.",
@@ -184,14 +184,14 @@ func TestLowerCase(t *testing.T) {
 		},
 		/*unicode*/
 		{
-			[]Region{{0, 74}},
+			[]text.Region{{0, 74}},
 
 			"ЧЕМ БОЛЬШЕ ЗАКОНОВ И ПОСТАНОВЛЕНИЙ, ТЕМ БОЛЬШЕ РАЗБОЙНИКОВ И ПРЕСТУПЛЕНИЙ!",
 			"чем больше законов и постановлений, тем больше разбойников и преступлений!",
 		},
 		/*asian characters*/
 		{
-			[]Region{{0, 9}},
+			[]text.Region{{0, 9}},
 
 			"千里之行﹐始于足下",
 			"千里之行﹐始于足下",

--- a/comment.go
+++ b/comment.go
@@ -17,7 +17,6 @@ type (
 	// entire selection is commented out, with existing comments being commented by an extra level.
 	// If the current selection has only content contained within comments, all of the comments are
 	// reduced by one level. All lines containing only whitespace are ignored in every case.
-
 	ToggleComment struct {
 		backend.DefaultCommand
 	}

--- a/comment.go
+++ b/comment.go
@@ -22,7 +22,7 @@ type (
 	}
 )
 
-// Run will execute the ToggleComment command
+// Run executes the ToggleComment command.
 func (c *ToggleComment) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Comment the line if we only have a cursor.
 	// TODO: Expand the selection after altering it.

--- a/comment.go
+++ b/comment.go
@@ -8,16 +8,20 @@ import (
 	"strings"
 	"unicode"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
+	//ToggleComment will add comment to the selection of
+	//lines if there is no comment, or it'll remove
+	//commen to the line selection if a comment is already present
 	ToggleComment struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *ToggleComment) Run(v *View, e *Edit) error {
+//Run will execute the ToggleComment command
+func (c *ToggleComment) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Comment the line if we only have a cursor.
 	// TODO: Expand the selection after altering it.
 	// TODO: Align the comment characters for multiline selections.
@@ -48,7 +52,7 @@ func (c *ToggleComment) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&ToggleComment{},
 	})
 }

--- a/comment.go
+++ b/comment.go
@@ -12,13 +12,12 @@ import (
 )
 
 type (
-	// ToggleComment converts the current selection into a comment,
-	// or add a comment depending if the selection contains any commented lines
-	// if it is already a comment, converts it back into plain text
-	// it'll add the comment symbol at the first character of the selection
-	// regardless if the line is already commented.
-	// While removing a comment during a toggle, it'll follow the same logic as above
-	// and it'll only remove one layer of comments
+	// ToggleComment toggles the comment status for the current selection.
+	// If the current selection has any content which is not currently contained within a comment, the
+	// entire selection is commented out, with existing comments being commented by an extra level.
+	// If the current selection has only content contained within comments, all of the comments are
+	// reduced by one level. All lines containing only whitespace are ignored in every case.
+
 	ToggleComment struct {
 		backend.DefaultCommand
 	}

--- a/comment.go
+++ b/comment.go
@@ -12,19 +12,22 @@ import (
 )
 
 type (
-	//ToggleComment will add comment to the selection of
-	//lines if there is no comment, or it'll remove
-	//commen to the line selection if a comment is already present
+	// ToggleComment converts the current selection into a comment,
+	// or, if it is already a comment, converts it back into plain text
+	// it'll add the comment symbol at the first character of the selection
+	// regardless if the line is already commented.
+	// While removing a comment during a toggle, it'll follow the same logic as above
+	// and it'll only remove one layer of comments
 	ToggleComment struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run will execute the ToggleComment command
+// Run will execute the ToggleComment command
 func (c *ToggleComment) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Comment the line if we only have a cursor.
 	// TODO: Expand the selection after altering it.
-	// TODO: Align the comment characters for multiline selections.
+	// TODO: Align the comment characters for multiline selection.
 	// TODO: Get the comment value from the Textmate files.
 	comm := "//"
 

--- a/comment.go
+++ b/comment.go
@@ -13,7 +13,8 @@ import (
 
 type (
 	// ToggleComment converts the current selection into a comment,
-	// or, if it is already a comment, converts it back into plain text
+	// or add a comment depending if the selection contains any commented lines
+	// if it is already a comment, converts it back into plain text
 	// it'll add the comment symbol at the first character of the selection
 	// regardless if the line is already commented.
 	// While removing a comment during a toggle, it'll follow the same logic as above

--- a/comment_test.go
+++ b/comment_test.go
@@ -7,7 +7,7 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 	"github.com/limetext/text"
 )
 
@@ -91,7 +91,7 @@ func TestToggleComment(t *testing.T) {
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 

--- a/copycutpaste.go
+++ b/copycutpaste.go
@@ -13,18 +13,18 @@ import (
 )
 
 type (
-	//Copy command will be used to copy
-	//the selected lines of text to the clipboard
+	// Copy copies the current selection to the clipboard.
+	// Lime has multiple selection, and Copy concatenates selections,
+	// top to bottom of the file, inserting a newline between each
 	Copy struct {
 		backend.DefaultCommand
 	}
-	//Cut command will be used to cut the selected lines
-	//from the view
+	// Cut copies the current selection to the clipboard and removes it from the buffer
 	Cut struct {
 		backend.DefaultCommand
 	}
-	//Paste command will be used to paste the clipboard
-	//contents into a view
+	// Paste command will be used to paste the clipboard
+	// contents into a view
 	Paste struct {
 		backend.DefaultCommand
 	}
@@ -62,7 +62,7 @@ func getSelSubstrs(v *backend.View, rs *text.RegionSet) []string {
 	return s
 }
 
-//Run will execute the Copy command when initialized
+// Run will execute the Copy command when initialized
 func (c *Copy) Run(v *backend.View, e *backend.Edit) error {
 	rs := getRegions(v, false)
 	s := getSelSubstrs(v, rs)
@@ -72,7 +72,7 @@ func (c *Copy) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the Cut command when initialized
+// Run will execute the Cut command when initialized
 func (c *Cut) Run(v *backend.View, e *backend.Edit) error {
 	s := getSelSubstrs(v, getRegions(v, false))
 
@@ -88,7 +88,7 @@ func (c *Cut) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the Paste command when initialized
+// Run will execute the Paste command when initialized
 func (c *Paste) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Paste the entire line on the line before the cursor if a
 	//		 line was autocopied.

--- a/copycutpaste.go
+++ b/copycutpaste.go
@@ -14,17 +14,19 @@ import (
 
 type (
 	// Copy copies the current selection to the clipboard.
-	// Lime has multiple selection, and Copy concatenates selections,
+	// since Lime has multiple selection, and Copy concatenates selections,
 	// top to bottom of the file, inserting a newline between each
 	Copy struct {
 		backend.DefaultCommand
 	}
+
 	// Cut copies the current selection to the clipboard and removes it from the buffer
 	Cut struct {
 		backend.DefaultCommand
 	}
-	// Paste command will be used to paste the clipboard
-	// contents into a view
+
+	// Paste command paste the clipboard
+	// contents into a view.
 	Paste struct {
 		backend.DefaultCommand
 	}
@@ -62,7 +64,7 @@ func getSelSubstrs(v *backend.View, rs *text.RegionSet) []string {
 	return s
 }
 
-// Run will execute the Copy command when initialized
+// Run executes the Copy command.
 func (c *Copy) Run(v *backend.View, e *backend.Edit) error {
 	rs := getRegions(v, false)
 	s := getSelSubstrs(v, rs)
@@ -72,7 +74,7 @@ func (c *Copy) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the Cut command when initialized
+// Run executes the Cut command.
 func (c *Cut) Run(v *backend.View, e *backend.Edit) error {
 	s := getSelSubstrs(v, getRegions(v, false))
 
@@ -88,7 +90,7 @@ func (c *Cut) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the Paste command when initialized
+// Run executes the Paste command when initialized
 func (c *Paste) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Paste the entire line on the line before the cursor if a
 	//		 line was autocopied.

--- a/copycutpaste.go
+++ b/copycutpaste.go
@@ -8,25 +8,29 @@ import (
 	"sort"
 	"strings"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 	"github.com/limetext/text"
 )
 
 type (
+	//Copy command will be used to copy
+	//the selected lines of text to the clipboard
 	Copy struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
-
+	//Cut command will be used to cut the selected lines
+	//from the view
 	Cut struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
-
+	//Paste command will be used to paste the clipboard
+	//contents into a view
 	Paste struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func getRegions(v *View, cut bool) *text.RegionSet {
+func getRegions(v *backend.View, cut bool) *text.RegionSet {
 	rs := &text.RegionSet{}
 	regions := v.Sel().Regions()
 	sort.Sort(regionSorter(regions))
@@ -44,7 +48,7 @@ func getRegions(v *View, cut bool) *text.RegionSet {
 	return rs
 }
 
-func getSelSubstrs(v *View, rs *text.RegionSet) []string {
+func getSelSubstrs(v *backend.View, rs *text.RegionSet) []string {
 	var add, s1 string
 	s := make([]string, len(rs.Regions()))
 	for i, r := range rs.Regions() {
@@ -58,16 +62,18 @@ func getSelSubstrs(v *View, rs *text.RegionSet) []string {
 	return s
 }
 
-func (c *Copy) Run(v *View, e *Edit) error {
+//Run will execute the Copy command when initialized
+func (c *Copy) Run(v *backend.View, e *backend.Edit) error {
 	rs := getRegions(v, false)
 	s := getSelSubstrs(v, rs)
 
-	GetEditor().SetClipboard(strings.Join(s, "\n"))
+	backend.GetEditor().SetClipboard(strings.Join(s, "\n"))
 
 	return nil
 }
 
-func (c *Cut) Run(v *View, e *Edit) error {
+//Run will execute the Cut command when initialized
+func (c *Cut) Run(v *backend.View, e *backend.Edit) error {
 	s := getSelSubstrs(v, getRegions(v, false))
 
 	rs := getRegions(v, true)
@@ -77,16 +83,17 @@ func (c *Cut) Run(v *View, e *Edit) error {
 		v.Erase(e, r)
 	}
 
-	GetEditor().SetClipboard(strings.Join(s, "\n"))
+	backend.GetEditor().SetClipboard(strings.Join(s, "\n"))
 
 	return nil
 }
 
-func (c *Paste) Run(v *View, e *Edit) error {
+//Run will execute the Paste command when initialized
+func (c *Paste) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Paste the entire line on the line before the cursor if a
 	//		 line was autocopied.
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 
 	rs := &text.RegionSet{}
 	regions := v.Sel().Regions()
@@ -100,7 +107,7 @@ func (c *Paste) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Copy{},
 		&Cut{},
 		&Paste{},

--- a/copycutpaste.go
+++ b/copycutpaste.go
@@ -13,20 +13,24 @@ import (
 )
 
 type (
-	// Copy copies the current selection to the clipboard.
-	// since Lime has multiple selection, and Copy concatenates selections,
-	// top to bottom of the file, inserting a newline between each
+	// Copy copies the current selection to the clipboard. If there
+	// are multiple selections, they are concatenated in order from
+	// top to bottom of the file, separated by newlines
 	Copy struct {
 		backend.DefaultCommand
 	}
 
-	// Cut copies the current selection to the clipboard and removes it from the buffer
+	// Cut copies the current selection to the clipboard, removing it from the buffer.
+	// If there are multiple selections, they are concatenated in order from top to
+	// bottom of the file, separated by newlines.
 	Cut struct {
 		backend.DefaultCommand
 	}
 
-	// Paste command paste the clipboard
-	// contents into a view.
+	// Paste pastes the contents of the clipboard, overwriting the current selection,
+	// if any. If there are multiple selections, the clipboard is split into lines.
+	// If the number of lines equals the number of selections, the lines are pasted
+	// separately into each selection in order from top to bottom of the file.
 	Paste struct {
 		backend.DefaultCommand
 	}

--- a/copycutpaste.go
+++ b/copycutpaste.go
@@ -94,7 +94,7 @@ func (c *Cut) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run executes the Paste command when initialized
+// Run executes the Paste command
 func (c *Paste) Run(v *backend.View, e *backend.Edit) error {
 	// TODO: Paste the entire line on the line before the cursor if a
 	//		 line was autocopied.

--- a/file.go
+++ b/file.go
@@ -1,6 +1,6 @@
-//  Copyright 2014 The lime Authors.
-//  Use of this source code is governed by a 2-clause
-//  BSD-style license that can be found in the LICENSE file.
+// Copyright 2014 The lime Authors.
+// Use of this source code is governed by a 2-clause
+// BSD-style license that can be found in the LICENSE file.
 
 package commands
 

--- a/file.go
+++ b/file.go
@@ -1,6 +1,6 @@
-// Copyright 2014 The lime Authors.
-// Use of this source code is governed by a 2-clause
-// BSD-style license that can be found in the LICENSE file.
+//  Copyright 2014 The lime Authors.
+//  Use of this source code is governed by a 2-clause
+//  BSD-style license that can be found in the LICENSE file.
 
 package commands
 
@@ -13,25 +13,25 @@ import (
 )
 
 type (
-	//NewFile command will be used to create a new file
+	// NewFile command will be used to create a new file
 	NewFile struct {
 		backend.DefaultCommand
 	}
-	//PromptOpenFile command will be used to prompt opening
-	//an existing file from the filesystem
+	// PromptOpenFile command will be used to prompt opening
+	// an existing file from the filesystem
 	PromptOpenFile struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run will execute the NewFile command
+// Run will execute the NewFile command
 func (c *NewFile) Run(w *backend.Window) error {
 	ed := backend.GetEditor()
 	ed.ActiveWindow().NewFile()
 	return nil
 }
 
-//Run will execute the PromptOpenFile command
+// Run will execute the PromptOpenFile command
 func (o *PromptOpenFile) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()

--- a/file.go
+++ b/file.go
@@ -9,36 +9,40 @@ import (
 	"os/user"
 	"path"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
+	//NewFile command will be used to create a new file
 	NewFile struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
-
+	//PromptOpenFile command will be used to prompt opening
+	//an existing file from the filesystem
 	PromptOpenFile struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *NewFile) Run(w *Window) error {
-	ed := GetEditor()
+//Run will execute the NewFile command
+func (c *NewFile) Run(w *backend.Window) error {
+	ed := backend.GetEditor()
 	ed.ActiveWindow().NewFile()
 	return nil
 }
 
-func (o *PromptOpenFile) Run(w *Window) error {
+//Run will execute the PromptOpenFile command
+func (o *PromptOpenFile) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
-	fe := GetEditor().Frontend()
-	files := fe.Prompt("Open file", dir, PROMPT_SELECT_MULTIPLE)
+	fe := backend.GetEditor().Frontend()
+	files := fe.Prompt("Open file", dir, backend.PROMPT_SELECT_MULTIPLE)
 	for _, file := range files {
 		w.OpenFile(file, 0)
 	}
 	return nil
 }
 
-func viewDirectory(v *View) string {
+func viewDirectory(v *backend.View) string {
 	if v != nil && v.FileName() != "" {
 		p := path.Dir(v.FileName())
 		if _, err := os.Stat(p); err == nil {
@@ -52,7 +56,7 @@ func viewDirectory(v *View) string {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&NewFile{},
 		&PromptOpenFile{},
 	})

--- a/file.go
+++ b/file.go
@@ -13,25 +13,25 @@ import (
 )
 
 type (
-	// NewFile command will be used to create a new file
+	// NewFile command creates a new file.
 	NewFile struct {
 		backend.DefaultCommand
 	}
-	// PromptOpenFile command will be used to prompt opening
-	// an existing file from the filesystem
+	// PromptOpenFile command prompts opening
+	// an existing file from the filesystem.
 	PromptOpenFile struct {
 		backend.DefaultCommand
 	}
 )
 
-// Run will execute the NewFile command
+// Run executes the NewFile command.
 func (c *NewFile) Run(w *backend.Window) error {
 	ed := backend.GetEditor()
 	ed.ActiveWindow().NewFile()
 	return nil
 }
 
-// Run will execute the PromptOpenFile command
+// Run executes the PromptOpenFile command.
 func (o *PromptOpenFile) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()

--- a/file_test.go
+++ b/file_test.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 func TestNewFile(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 
 	w := ed.NewWindow()
 	defer w.Close()
@@ -36,7 +36,7 @@ func TestOpenFile(t *testing.T) {
 	const testPath = "file_test.go"
 	fe.files = []string{testPath}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetFrontend(&fe)
 	w := ed.NewWindow()
 	defer w.Close()

--- a/findreplace.go
+++ b/findreplace.go
@@ -43,7 +43,7 @@ var (
 	replaceText string
 )
 
-// Run will execute the FindUnderExpand command
+// Run executes the FindUnderExpand command.
 func (c *FindUnderExpand) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	rs := sel.Regions()
@@ -94,7 +94,7 @@ func nextSelection(v *backend.View, search string) (text.Region, error) {
 	return text.Region{-1, -1}, errors.New("Selection not Found")
 }
 
-// Run will execute the FindNext command
+// Run executes the FindNext command.
 func (c *FindNext) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of FindNext:
@@ -121,7 +121,7 @@ func (c *FindNext) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the ReplaceNext command
+// Run executes the ReplaceNext command.
 func (c *ReplaceNext) Run(v *backend.View, e *backend.Edit) error {
 	// use selection function from find.go to get the next region
 	selection, err := nextSelection(v, string(lastSearch))

--- a/findreplace.go
+++ b/findreplace.go
@@ -43,7 +43,7 @@ var (
 	replaceText string
 )
 
-//Run will execute the FindUnderExpand command
+// Run will execute the FindUnderExpand command
 func (c *FindUnderExpand) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	rs := sel.Regions()
@@ -94,7 +94,7 @@ func nextSelection(v *backend.View, search string) (text.Region, error) {
 	return text.Region{-1, -1}, errors.New("Selection not Found")
 }
 
-//Run will execute the FindNext command
+// Run will execute the FindNext command
 func (c *FindNext) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of FindNext:
@@ -121,7 +121,7 @@ func (c *FindNext) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the ReplaceNext command
+// Run will execute the ReplaceNext command
 func (c *ReplaceNext) Run(v *backend.View, e *backend.Edit) error {
 	// use selection function from find.go to get the next region
 	selection, err := nextSelection(v, string(lastSearch))

--- a/findreplace.go
+++ b/findreplace.go
@@ -7,33 +7,33 @@ package commands
 import (
 	"errors"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type (
-	// The FindUnderExpandCommand extends the selection to the current word
+	// FindUnderExpand Command extends the selection to the current word
 	// if the current selection region is empty.
 	// If one character or more is selected, the text buffer is scanned for
 	// the next occurrence of the selection and that region too is added to
 	// the selection set.
 	FindUnderExpand struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
-	// The FindNext command searches for the last search term, starting at
+	// FindNext command searches for the last search term, starting at
 	// the end of the last selection in the buffer, and wrapping around. If
 	// it finds the term, it clears the current selections and selects the
 	// newly-found regions.
 	FindNext struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The ReplaceNextCommand searches for the "old" argument text,
+	// ReplaceNext Command searches for the "old" argument text,
 	// and at the first occurance of the text, replaces it with the
 	// "new" argument text. If there are multiple regions, the find
 	// starts from the max region.
 	ReplaceNext struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
@@ -43,7 +43,8 @@ var (
 	replaceText string
 )
 
-func (c *FindUnderExpand) Run(v *View, e *Edit) error {
+//Run will execute the FindUnderExpand command
+func (c *FindUnderExpand) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	rs := sel.Regions()
 
@@ -60,14 +61,14 @@ func (c *FindUnderExpand) Run(v *View, e *Edit) error {
 	}
 	last := rs[len(rs)-1]
 	lastSearch = v.SubstrR(last)
-	r := v.Find(string(lastSearch), last.End(), IGNORECASE|LITERAL)
+	r := v.Find(string(lastSearch), last.End(), backend.IGNORECASE|backend.LITERAL)
 	if r.A != -1 {
 		sel.Add(r)
 	}
 	return nil
 }
 
-func nextSelection(v *View, search string) (Region, error) {
+func nextSelection(v *backend.View, search string) (text.Region, error) {
 	sel := v.Sel()
 	rs := sel.Regions()
 	last := 0
@@ -75,25 +76,26 @@ func nextSelection(v *View, search string) (Region, error) {
 
 	// Regions are not sorted, so finding the last one requires a search.
 	for _, r := range rs {
-		last = Max(last, r.End())
+		last = text.Max(last, r.End())
 	}
 
 	// Start the search right after the last selection.
 	start := last
-	r := v.Find(search, start, IGNORECASE|LITERAL)
+	r := v.Find(search, start, backend.IGNORECASE|backend.LITERAL)
 	// If not found yet and find_wrap setting is true, search
 	// from the start of the buffer to our original starting point.
 	if r.A == -1 && wrap {
-		r = v.Find(search, 0, IGNORECASE|LITERAL)
+		r = v.Find(search, 0, backend.IGNORECASE|backend.LITERAL)
 	}
 	// If we found our string, select it.
 	if r.A != -1 {
 		return r, nil
 	}
-	return Region{-1, -1}, errors.New("Selection not Found")
+	return text.Region{-1, -1}, errors.New("Selection not Found")
 }
 
-func (c *FindNext) Run(v *View, e *Edit) error {
+//Run will execute the FindNext command
+func (c *FindNext) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of FindNext:
 			- If there is no previous search, do nothing
@@ -119,7 +121,8 @@ func (c *FindNext) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *ReplaceNext) Run(v *View, e *Edit) error {
+//Run will execute the ReplaceNext command
+func (c *ReplaceNext) Run(v *backend.View, e *backend.Edit) error {
 	// use selection function from find.go to get the next region
 	selection, err := nextSelection(v, string(lastSearch))
 	if err != nil {
@@ -131,7 +134,7 @@ func (c *ReplaceNext) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&FindUnderExpand{},
 		&FindNext{},
 		&ReplaceNext{},

--- a/findreplace_test.go
+++ b/findreplace_test.go
@@ -8,19 +8,19 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type findTest struct {
 	text string
-	in   []Region
-	exp  []Region
+	in   []text.Region
+	exp  []text.Region
 	fw   bool
 }
 
 func runFindTest(tests []findTest, t *testing.T, commands ...string) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -48,7 +48,7 @@ func runFindTest(tests []findTest, t *testing.T, commands ...string) {
 			t.Errorf("Test %d: Expected %s, but got %s", i, test.exp, sr)
 		}
 		e = v.BeginEdit()
-		v.Erase(e, Region{0, v.Size()})
+		v.Erase(e, text.Region{0, v.Size()})
 		v.EndEdit(e)
 	}
 }
@@ -57,14 +57,14 @@ func TestFindUnderExpand(t *testing.T) {
 	tests := []findTest{
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{0, 0}},
-			[]Region{{0, 5}},
+			[]text.Region{{0, 0}},
+			[]text.Region{{0, 5}},
 			true,
 		},
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{19, 20}},
-			[]Region{{19, 20}, {22, 23}},
+			[]text.Region{{19, 20}},
+			[]text.Region{{19, 20}, {22, 23}},
 			true,
 		},
 	}
@@ -76,22 +76,22 @@ func TestFindNext(t *testing.T) {
 	tests := []findTest{
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{17, 20}},
-			[]Region{{17, 20}},
+			[]text.Region{{17, 20}},
+			[]text.Region{{17, 20}},
 			true,
 		},
 		// test find_wrap setting true
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{21, 23}},
-			[]Region{{18, 20}},
+			[]text.Region{{21, 23}},
+			[]text.Region{{18, 20}},
 			true,
 		},
 		// test find_wrap setting false
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{21, 23}},
-			[]Region{{21, 23}},
+			[]text.Region{{21, 23}},
+			[]text.Region{{21, 23}},
 			false,
 		},
 	}
@@ -100,14 +100,14 @@ func TestFindNext(t *testing.T) {
 }
 
 type replaceTest struct {
-	cursors []Region
+	cursors []text.Region
 	in      string
 	exp     string
 	fw      bool
 }
 
 func runReplaceTest(tests []replaceTest, t *testing.T, commands ...string) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -133,11 +133,11 @@ func runReplaceTest(tests []replaceTest, t *testing.T, commands ...string) {
 		for _, command := range commands {
 			ed.CommandHandler().RunTextCommand(v, command, nil)
 		}
-		if out := v.Substr(Region{0, v.Size()}); out != test.exp {
+		if out := v.Substr(text.Region{0, v.Size()}); out != test.exp {
 			t.Errorf("Test %d failed: %s, %+v", i, out, test)
 		}
 		e = v.BeginEdit()
-		v.Erase(e, Region{0, v.Size()})
+		v.Erase(e, text.Region{0, v.Size()})
 		v.EndEdit(e)
 	}
 }
@@ -145,45 +145,45 @@ func runReplaceTest(tests []replaceTest, t *testing.T, commands ...string) {
 func TestReplaceNext(t *testing.T) {
 	tests := []replaceTest{
 		{
-			[]Region{{1, 1}, {2, 2}, {3, 3}},
+			[]text.Region{{1, 1}, {2, 2}, {3, 3}},
 			"abc abc bac abc abc",
 			"abc f bac abc abc",
 			true,
 		},
 		{
-			[]Region{{0, 0}, {4, 4}, {8, 8}, {12, 13}},
+			[]text.Region{{0, 0}, {4, 4}, {8, 8}, {12, 13}},
 			"abc abc bac abc abc",
 			"abc abc bac abc f",
 			true,
 		},
 		{
-			[]Region{{12, 13}, {8, 8}, {4, 4}, {1, 0}},
+			[]text.Region{{12, 13}, {8, 8}, {4, 4}, {1, 0}},
 			"abc abc bac abc abc",
 			"abc abc bac abc f",
 			true,
 		},
 		{
-			[]Region{{15, 15}},
+			[]text.Region{{15, 15}},
 			"abc abc bac abc abc",
 			"abc abc bac abc f",
 			true,
 		},
 		{
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			"abc abc bac abc abc",
 			"abc f bac abc abc",
 			true,
 		},
 		// test find_wrap setting true
 		{
-			[]Region{{16, 19}},
+			[]text.Region{{16, 19}},
 			"abc abc bac abc abc",
 			"f abc bac abc abc",
 			true,
 		},
 		// test find_wrap setting false
 		{
-			[]Region{{16, 19}},
+			[]text.Region{{16, 19}},
 			"abc abc bac abc abc",
 			"abc abc bac abc abc",
 			false,

--- a/glue.go
+++ b/glue.go
@@ -7,54 +7,57 @@ package commands
 import (
 	"fmt"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
-const lime_cmd_mark = "lime.cmd.mark"
+const limeCmdMark = "lime.cmd.mark"
 
 type (
-	// The MarkUndoGroupsForGluingCommand marks the current position
+	// MarkUndoGroupsForGluing Command marks the current position
 	// in the undo stack as the start of commands to glue, potentially
 	// overwriting any existing marks.
 	MarkUndoGroupsForGluing struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
 
-	// The GlueMarkedUndoGroupsCommand merges commands from the previously
+	// GlueMarkedUndoGroups Command merges commands from the previously
 	// marked undo stack location to the current location into a single
 	// entry in the undo stack.
 	GlueMarkedUndoGroups struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
 
-	// The MaybeMarkUndoGroupsForGluingCommand is similar to
+	// MaybeMarkUndoGroupsForGluing Command is similar to
 	// MarkUndoGroupsForGluingCommand with the exception that if there
 	// is already a mark set, it is not overwritten.
 	MaybeMarkUndoGroupsForGluing struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
 
-	// The UnmarkUndoGroupsForGluingCommand removes the glue mark set by
+	// UnmarkUndoGroupsForGluing Command removes the glue mark set by
 	// either MarkUndoGroupsForGluingCommand or MaybeMarkUndoGroupsForGluingCommand
 	// if it was set.
 	UnmarkUndoGroupsForGluing struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
 )
 
-func (c *MarkUndoGroupsForGluing) Run(v *View, e *Edit) error {
-	v.Settings().Set(lime_cmd_mark, v.UndoStack().Position())
+//Run wil execute the MarkUndoGroupsForGluing command
+func (c *MarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
+	v.Settings().Set(limeCmdMark, v.UndoStack().Position())
 	return nil
 }
 
-func (c *UnmarkUndoGroupsForGluing) Run(v *View, e *Edit) error {
-	v.Settings().Erase(lime_cmd_mark)
+//Run wil execute the UnmarkUndoGroupsForGluing command
+func (c *UnmarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
+	v.Settings().Erase(limeCmdMark)
 	return nil
 }
 
-func (c *GlueMarkedUndoGroups) Run(v *View, e *Edit) error {
+//Run wil execute the GlueMarkedUndoGroups command
+func (c *GlueMarkedUndoGroups) Run(v *backend.View, e *backend.Edit) error {
 	pos := v.UndoStack().Position()
-	mark, ok := v.Settings().Get(lime_cmd_mark).(int)
+	mark, ok := v.Settings().Get(limeCmdMark).(int)
 	if !ok {
 		return fmt.Errorf("No mark in the current view")
 	}
@@ -64,15 +67,16 @@ func (c *GlueMarkedUndoGroups) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *MaybeMarkUndoGroupsForGluing) Run(v *View, e *Edit) error {
-	if !v.Settings().Has(lime_cmd_mark) {
-		v.Settings().Set(lime_cmd_mark, v.UndoStack().Position())
+//Run wil execute the MaybeMarkUndoGroupsForGluing command
+func (c *MaybeMarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
+	if !v.Settings().Has(limeCmdMark) {
+		v.Settings().Set(limeCmdMark, v.UndoStack().Position())
 	}
 	return nil
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&MarkUndoGroupsForGluing{},
 		&GlueMarkedUndoGroups{},
 		&MaybeMarkUndoGroupsForGluing{},

--- a/glue.go
+++ b/glue.go
@@ -42,19 +42,19 @@ type (
 	}
 )
 
-//Run wil execute the MarkUndoGroupsForGluing command
+// Run wil execute the MarkUndoGroupsForGluing command
 func (c *MarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
 	v.Settings().Set(limeCmdMark, v.UndoStack().Position())
 	return nil
 }
 
-//Run wil execute the UnmarkUndoGroupsForGluing command
+// Run wil execute the UnmarkUndoGroupsForGluing command
 func (c *UnmarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
 	v.Settings().Erase(limeCmdMark)
 	return nil
 }
 
-//Run wil execute the GlueMarkedUndoGroups command
+// Run wil execute the GlueMarkedUndoGroups command
 func (c *GlueMarkedUndoGroups) Run(v *backend.View, e *backend.Edit) error {
 	pos := v.UndoStack().Position()
 	mark, ok := v.Settings().Get(limeCmdMark).(int)
@@ -67,7 +67,7 @@ func (c *GlueMarkedUndoGroups) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run wil execute the MaybeMarkUndoGroupsForGluing command
+// Run wil execute the MaybeMarkUndoGroupsForGluing command
 func (c *MaybeMarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
 	if !v.Settings().Has(limeCmdMark) {
 		v.Settings().Set(limeCmdMark, v.UndoStack().Position())

--- a/glue.go
+++ b/glue.go
@@ -42,19 +42,19 @@ type (
 	}
 )
 
-// Run wil execute the MarkUndoGroupsForGluing command
+// Run executes the MarkUndoGroupsForGluing command.
 func (c *MarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
 	v.Settings().Set(limeCmdMark, v.UndoStack().Position())
 	return nil
 }
 
-// Run wil execute the UnmarkUndoGroupsForGluing command
+// Run executes the UnmarkUndoGroupsForGluing command.
 func (c *UnmarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
 	v.Settings().Erase(limeCmdMark)
 	return nil
 }
 
-// Run wil execute the GlueMarkedUndoGroups command
+// Run executes the GlueMarkedUndoGroups command.
 func (c *GlueMarkedUndoGroups) Run(v *backend.View, e *backend.Edit) error {
 	pos := v.UndoStack().Position()
 	mark, ok := v.Settings().Get(limeCmdMark).(int)
@@ -67,7 +67,7 @@ func (c *GlueMarkedUndoGroups) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run wil execute the MaybeMarkUndoGroupsForGluing command
+// Run executes the MaybeMarkUndoGroupsForGluing command.
 func (c *MaybeMarkUndoGroupsForGluing) Run(v *backend.View, e *backend.Edit) error {
 	if !v.Settings().Has(limeCmdMark) {
 		v.Settings().Set(limeCmdMark, v.UndoStack().Position())

--- a/glue_test.go
+++ b/glue_test.go
@@ -7,12 +7,12 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 	"github.com/limetext/text"
 )
 
 func TestGlueCmds(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ch := ed.CommandHandler()
 	w := ed.NewWindow()
 	defer w.Close()
@@ -29,9 +29,9 @@ func TestGlueCmds(t *testing.T) {
 	v.EndEdit(e)
 	v.SetScratch(false)
 	ch.RunTextCommand(v, "mark_undo_groups_for_gluing", nil)
-	ch.RunTextCommand(v, "insert", Args{"characters": "a"})
-	ch.RunTextCommand(v, "insert", Args{"characters": "b"})
-	ch.RunTextCommand(v, "insert", Args{"characters": "c"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "a"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "b"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "c"})
 	ch.RunTextCommand(v, "glue_marked_undo_groups", nil)
 	if v.UndoStack().Position() != 1 {
 		t.Error(v.UndoStack().Position())
@@ -57,11 +57,11 @@ func TestGlueCmds(t *testing.T) {
 	}
 
 	ch.RunTextCommand(v, "maybe_mark_undo_groups_for_gluing", nil)
-	ch.RunTextCommand(v, "insert", Args{"characters": "a"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "a"})
 	ch.RunTextCommand(v, "maybe_mark_undo_groups_for_gluing", nil)
-	ch.RunTextCommand(v, "insert", Args{"characters": "b"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "b"})
 	ch.RunTextCommand(v, "maybe_mark_undo_groups_for_gluing", nil)
-	ch.RunTextCommand(v, "insert", Args{"characters": "c"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "c"})
 	ch.RunTextCommand(v, "maybe_mark_undo_groups_for_gluing", nil)
 	ch.RunTextCommand(v, "glue_marked_undo_groups", nil)
 	if v.UndoStack().Position() != 1 {
@@ -84,13 +84,13 @@ func TestGlueCmds(t *testing.T) {
 	}
 
 	ch.RunTextCommand(v, "mark_undo_groups_for_gluing", nil)
-	ch.RunTextCommand(v, "move", Args{"forward": false, "extend": true, "by": "lines"})
-	ch.RunTextCommand(v, "move", Args{"forward": false, "extend": true, "by": "lines"})
-	ch.RunTextCommand(v, "move", Args{"forward": false, "extend": true, "by": "lines"})
+	ch.RunTextCommand(v, "move", backend.Args{"forward": false, "extend": true, "by": "lines"})
+	ch.RunTextCommand(v, "move", backend.Args{"forward": false, "extend": true, "by": "lines"})
+	ch.RunTextCommand(v, "move", backend.Args{"forward": false, "extend": true, "by": "lines"})
 	ch.RunTextCommand(v, "left_delete", nil)
-	ch.RunTextCommand(v, "insert", Args{"characters": "a"})
-	ch.RunTextCommand(v, "insert", Args{"characters": "b"})
-	ch.RunTextCommand(v, "insert", Args{"characters": "c"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "a"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "b"})
+	ch.RunTextCommand(v, "insert", backend.Args{"characters": "c"})
 	ch.RunTextCommand(v, "glue_marked_undo_groups", nil)
 	if v.UndoStack().Position() != 2 {
 		t.Error(v.UndoStack().Position())

--- a/indent.go
+++ b/indent.go
@@ -23,7 +23,7 @@ type (
 	}
 )
 
-// Run will execute the Indent command
+// Run executes the Indent command.
 func (c *Indent) Run(v *backend.View, e *backend.Edit) error {
 	indent := "\t"
 	if t := v.Settings().Bool("translate_tabs_to_spaces", false); t {
@@ -44,7 +44,7 @@ func (c *Indent) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the Unindent command
+// Run executes the Unindent command.
 func (c *Unindent) Run(v *backend.View, e *backend.Edit) error {
 	tabSize := v.Settings().Int("tab_size", 4)
 	sel := v.Sel()

--- a/indent.go
+++ b/indent.go
@@ -7,23 +7,24 @@ package commands
 import (
 	"strings"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type (
-	// The IndentCommand increments indentation of selection.
+	// Indent Command increments indentation of selection.
 	Indent struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The UnindentCommand decrements indentation of selection.
+	// Unindent Command decrements indentation of selection.
 	Unindent struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *Indent) Run(v *View, e *Edit) error {
+//Run will execute the Indent command
+func (c *Indent) Run(v *backend.View, e *backend.Edit) error {
 	indent := "\t"
 	if t := v.Settings().Bool("translate_tabs_to_spaces", false); t {
 		indent = strings.Repeat(" ", v.Settings().Int("tab_size", 4))
@@ -32,9 +33,9 @@ func (c *Indent) Run(v *View, e *Edit) error {
 
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
-		start_row, _ := v.RowCol(r.Begin())
-		end_row, _ := v.RowCol(r.End())
-		for row := start_row; row <= end_row; row++ {
+		startRow, _ := v.RowCol(r.Begin())
+		endRow, _ := v.RowCol(r.End())
+		for row := startRow; row <= endRow; row++ {
 			// Insert an indent at the beginning of the line
 			pos := v.TextPoint(row, 0)
 			v.Insert(e, pos, indent)
@@ -43,33 +44,34 @@ func (c *Indent) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *Unindent) Run(v *View, e *Edit) error {
-	tab_size := v.Settings().Int("tab_size", 4)
+//Run will execute the Unindent command
+func (c *Unindent) Run(v *backend.View, e *backend.Edit) error {
+	tabSize := v.Settings().Int("tab_size", 4)
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
-		start_row, _ := v.RowCol(r.Begin())
-		end_row, _ := v.RowCol(r.End())
-		for row := start_row; row <= end_row; row++ {
+		startRow, _ := v.RowCol(r.Begin())
+		endRow, _ := v.RowCol(r.End())
+		for row := startRow; row <= endRow; row++ {
 			pos := v.TextPoint(row, 0)
 			// Get the first at the beginning of the line (as many as defined by tab_size)
-			sub := v.Substr(Region{pos, pos + tab_size})
+			sub := v.Substr(text.Region{pos, pos + tabSize})
 			if len(sub) == 0 {
 				continue
 			}
-			to_remove := 0
+			toRemove := 0
 			if sub[0] == byte('\t') {
 				// Case 1: the first character is a tab, remove only it
-				to_remove = 1
+				toRemove = 1
 			} else if sub[0] == byte(' ') {
 				// Case 2: the first character is a space, we remove as much spaces as we can
-				to_remove = 1
-				for to_remove < len(sub) && sub[to_remove] == byte(' ') {
-					to_remove++
+				toRemove = 1
+				for toRemove < len(sub) && sub[toRemove] == byte(' ') {
+					toRemove++
 				}
 			}
-			if to_remove > 0 {
-				v.Erase(e, Region{pos, pos + to_remove})
+			if toRemove > 0 {
+				v.Erase(e, text.Region{pos, pos + toRemove})
 			}
 		}
 	}
@@ -77,7 +79,7 @@ func (c *Unindent) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Indent{},
 		&Unindent{},
 	})

--- a/indent.go
+++ b/indent.go
@@ -23,7 +23,7 @@ type (
 	}
 )
 
-//Run will execute the Indent command
+// Run will execute the Indent command
 func (c *Indent) Run(v *backend.View, e *backend.Edit) error {
 	indent := "\t"
 	if t := v.Settings().Bool("translate_tabs_to_spaces", false); t {
@@ -44,7 +44,7 @@ func (c *Indent) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the Unindent command
+// Run will execute the Unindent command
 func (c *Unindent) Run(v *backend.View, e *backend.Edit) error {
 	tabSize := v.Settings().Int("tab_size", 4)
 	sel := v.Sel()

--- a/indent_test.go
+++ b/indent_test.go
@@ -7,20 +7,20 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type indentTest struct {
-	text                     string
-	translate_tabs_to_spaces interface{}
-	tab_size                 interface{}
-	sel                      []Region
-	expect                   string
+	text                  string
+	translateTabsToSpaces interface{}
+	tabSize               interface{}
+	sel                   []text.Region
+	expect                string
 }
 
 func runIndentTest(t *testing.T, tests []indentTest, command string) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -40,16 +40,16 @@ func runIndentTest(t *testing.T, tests []indentTest, command string) {
 			v.Sel().Add(r)
 		}
 
-		if val, ok := test.translate_tabs_to_spaces.(bool); ok {
+		if val, ok := test.translateTabsToSpaces.(bool); ok {
 			v.Settings().Set("translate_tabs_to_spaces", val)
 		}
 
-		if val, ok := test.tab_size.(int); ok {
+		if val, ok := test.tabSize.(int); ok {
 			v.Settings().Set("tab_size", val)
 		}
 
 		ed.CommandHandler().RunTextCommand(v, command, nil)
-		if d := v.Substr(Region{0, v.Size()}); d != test.expect {
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expect {
 			t.Errorf("Test %d: Expected \n%q, but got \n%q", i, test.expect, d)
 		}
 	}
@@ -62,7 +62,7 @@ func TestIndent(t *testing.T) {
 			"a\n b\n  c\n   d\n",
 			false,
 			4,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"\ta\n b\n  c\n   d\n",
 		},
 		{ // translate_tabs_to_spaces = nil
@@ -70,7 +70,7 @@ func TestIndent(t *testing.T) {
 			"a\n b\n  c\n   d\n",
 			nil,
 			1,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"\ta\n b\n  c\n   d\n",
 		},
 		{ // translate_tabs_to_spaces = true and tab_size = 2
@@ -78,7 +78,7 @@ func TestIndent(t *testing.T) {
 			"a\n b\n  c\n   d\n",
 			true,
 			2,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"  a\n b\n  c\n   d\n",
 		},
 		{ // translate_tabs_to_spaces = true and tab_size = nil
@@ -86,7 +86,7 @@ func TestIndent(t *testing.T) {
 			"a\n b\n  c\n   d\n",
 			true,
 			nil,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"    a\n b\n  c\n   d\n",
 		},
 		{ // region include the 1st line and the 4th line
@@ -94,7 +94,7 @@ func TestIndent(t *testing.T) {
 			"a\n b\n  c\n   d\n",
 			false,
 			1,
-			[]Region{{0, 1}, {11, 12}},
+			[]text.Region{{0, 1}, {11, 12}},
 			"\ta\n b\n  c\n\t   d\n",
 		},
 		{ // region selected reversely
@@ -102,7 +102,7 @@ func TestIndent(t *testing.T) {
 			"a\n b\n  c\n   d\n",
 			false,
 			1,
-			[]Region{{3, 0}},
+			[]text.Region{{3, 0}},
 			"\ta\n\t b\n  c\n   d\n",
 		},
 	}
@@ -117,7 +117,7 @@ func TestUnindent(t *testing.T) {
 			"\ta\n  b\n      c\n\t  d\n",
 			false,
 			4,
-			[]Region{{0, 19}},
+			[]text.Region{{0, 19}},
 			"a\nb\n  c\n  d\n",
 		},
 		{ // translate_tabs_to_spaces = nil
@@ -125,7 +125,7 @@ func TestUnindent(t *testing.T) {
 			"\ta\n b\n  c\n   d\n",
 			nil,
 			1,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"a\n b\n  c\n   d\n",
 		},
 		{ // translate_tabs_to_spaces = true and tab_size = 2
@@ -133,7 +133,7 @@ func TestUnindent(t *testing.T) {
 			"  a\n b\n  c\n   d\n",
 			true,
 			2,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"a\n b\n  c\n   d\n",
 		},
 		{ // translate_tabs_to_spaces = true and tab_size = nil
@@ -141,7 +141,7 @@ func TestUnindent(t *testing.T) {
 			"    a\n b\n  c\n   d\n",
 			true,
 			nil,
-			[]Region{{0, 1}},
+			[]text.Region{{0, 1}},
 			"a\n b\n  c\n   d\n",
 		},
 		{ // region include the 1st line and the 4th line
@@ -149,7 +149,7 @@ func TestUnindent(t *testing.T) {
 			"\ta\n b\n  c\n \t   d\n",
 			false,
 			1,
-			[]Region{{0, 1}, {11, 12}},
+			[]text.Region{{0, 1}, {11, 12}},
 			"a\n b\n  c\n\t   d\n",
 		},
 		{ // region selected reversely
@@ -157,7 +157,7 @@ func TestUnindent(t *testing.T) {
 			"\ta\n\t b\n  c\n   d\n",
 			false,
 			4,
-			[]Region{{3, 0}},
+			[]text.Region{{3, 0}},
 			"a\n b\n  c\n   d\n",
 		},
 		{ // empty strings
@@ -165,7 +165,7 @@ func TestUnindent(t *testing.T) {
 			"",
 			false,
 			nil,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			"",
 		},
 	}

--- a/insdel.go
+++ b/insdel.go
@@ -41,7 +41,7 @@ type (
 	}
 )
 
-//Run will execute the Insert command
+// Run will execute the Insert command
 func (c *Insert) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -55,7 +55,7 @@ func (c *Insert) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the LeftDelete command
+// Run executes the LeftDelete command
 func (c *LeftDelete) Run(v *backend.View, e *backend.Edit) error {
 	trimSpace := false
 	tabSize := 4
@@ -102,7 +102,7 @@ func (c *LeftDelete) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the RightDelete command
+// Run will execute the RightDelete command
 func (c *RightDelete) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	hasNonEmpty := sel.HasNonEmpty()
@@ -125,7 +125,7 @@ func (c *RightDelete) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the DeleteWord command
+// Run will execute the DeleteWord command
 func (c *DeleteWord) Run(v *backend.View, e *backend.Edit) error {
 	var class int
 	if c.Forward {

--- a/insdel.go
+++ b/insdel.go
@@ -7,41 +7,42 @@ package commands
 import (
 	"strings"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 	"github.com/limetext/text"
 )
 
 type (
-	// The InsertCommand inserts the given characters, at all
+	// Insert Command inserts the given characters, at all
 	// of the current selection locations, possibly replacing
 	// text if the selection area covers one or more characters.
 	Insert struct {
-		DefaultCommand
+		backend.DefaultCommand
 		// The characters to insert
 		Characters string
 	}
 
-	// The LeftDeleteCommand deletes characters to the left of the
+	// LeftDelete Command deletes characters to the left of the
 	// current selection or the current selection if it is not empty.
 	LeftDelete struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The RightDeleteCommand deletes characters to the right of the
+	// RightDelete Command deletes characters to the right of the
 	// current selection or the current selection if it is not empty.
 	RightDelete struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
-	// The DeleteWordCommand deletes one word to right or left
+	// DeleteWord Command deletes one word to right or left
 	// depending on forward variable
 	DeleteWord struct {
-		DefaultCommand
+		backend.DefaultCommand
 		Forward bool
 	}
 )
 
-func (c *Insert) Run(v *View, e *Edit) error {
+//Run will execute the Insert command
+func (c *Insert) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
@@ -54,13 +55,14 @@ func (c *Insert) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *LeftDelete) Run(v *View, e *Edit) error {
-	trim_space := false
-	tab_size := 4
+//Run executes the LeftDelete command
+func (c *LeftDelete) Run(v *backend.View, e *backend.Edit) error {
+	trimSpace := false
+	tabSize := 4
 	if t := v.Settings().Bool("translate_tabs_to_spaces", false); t {
 		if t = v.Settings().Bool("use_tab_stops", true); t {
-			trim_space = true
-			tab_size = v.Settings().Int("tab_size", 4)
+			trimSpace = true
+			tabSize = v.Settings().Int("tab_size", 4)
 		}
 	}
 
@@ -74,15 +76,15 @@ func (c *LeftDelete) Run(v *View, e *Edit) error {
 		}
 		r := sel.Get(i)
 		if r.A == r.B && !hasNonEmpty {
-			if trim_space {
+			if trimSpace {
 				_, col := v.RowCol(r.A)
-				prev_col := r.A - (col - (col-tab_size+(tab_size-1))&^(tab_size-1))
-				if prev_col < 0 {
-					prev_col = 0
+				prevCol := r.A - (col - (col-tabSize+(tabSize-1))&^(tabSize-1))
+				if prevCol < 0 {
+					prevCol = 0
 				}
-				d := v.SubstrR(text.Region{A: prev_col, B: r.A})
+				d := v.SubstrR(text.Region{A: prevCol, B: r.A})
 				i := len(d) - 1
-				for r.A > prev_col && i >= 0 && d[i] == ' ' {
+				for r.A > prevCol && i >= 0 && d[i] == ' ' {
 					r.A--
 					i--
 				}
@@ -100,7 +102,8 @@ func (c *LeftDelete) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *RightDelete) Run(v *View, e *Edit) error {
+//Run will execute the RightDelete command
+func (c *RightDelete) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	hasNonEmpty := sel.HasNonEmpty()
 	i := 0
@@ -122,12 +125,13 @@ func (c *RightDelete) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *DeleteWord) Run(v *View, e *Edit) error {
+//Run will execute the DeleteWord command
+func (c *DeleteWord) Run(v *backend.View, e *backend.Edit) error {
 	var class int
 	if c.Forward {
-		class = CLASS_WORD_END | CLASS_PUNCTUATION_END | CLASS_LINE_START
+		class = backend.CLASS_WORD_END | backend.CLASS_PUNCTUATION_END | backend.CLASS_LINE_START
 	} else {
-		class = CLASS_WORD_START | CLASS_PUNCTUATION_START | CLASS_LINE_END | CLASS_LINE_START
+		class = backend.CLASS_WORD_START | backend.CLASS_PUNCTUATION_START | backend.CLASS_LINE_END | backend.CLASS_LINE_START
 	}
 
 	sel := v.Sel()
@@ -147,14 +151,14 @@ func (c *DeleteWord) Run(v *View, e *Edit) error {
 	sel.Clear()
 	sel.AddAll(rs)
 	if c.Forward {
-		GetEditor().CommandHandler().RunTextCommand(v, "right_delete", nil)
+		backend.GetEditor().CommandHandler().RunTextCommand(v, "right_delete", nil)
 	} else {
-		GetEditor().CommandHandler().RunTextCommand(v, "left_delete", nil)
+		backend.GetEditor().CommandHandler().RunTextCommand(v, "left_delete", nil)
 	}
 	return nil
 }
 
-func (c *DeleteWord) findByClass(point int, class int, v *View) int {
+func (c *DeleteWord) findByClass(point int, class int, v *backend.View) int {
 	var end, d int
 	if c.Forward {
 		d = 1
@@ -164,7 +168,7 @@ func (c *DeleteWord) findByClass(point int, class int, v *View) int {
 		}
 		s := v.Substr(text.Region{A: point, B: point + 2})
 		if strings.Contains(s, "\t") && strings.Contains(s, " ") {
-			class = CLASS_WORD_START | CLASS_PUNCTUATION_START | CLASS_LINE_END
+			class = backend.CLASS_WORD_START | backend.CLASS_PUNCTUATION_START | backend.CLASS_LINE_END
 		}
 	} else {
 		d = -1
@@ -174,7 +178,7 @@ func (c *DeleteWord) findByClass(point int, class int, v *View) int {
 		}
 		s := v.Substr(text.Region{A: point - 2, B: point})
 		if strings.Contains(s, "\t") && strings.Contains(s, " ") {
-			class = CLASS_WORD_END | CLASS_PUNCTUATION_END | CLASS_LINE_START
+			class = backend.CLASS_WORD_END | backend.CLASS_PUNCTUATION_END | backend.CLASS_LINE_START
 		}
 	}
 	point += d
@@ -187,7 +191,7 @@ func (c *DeleteWord) findByClass(point int, class int, v *View) int {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Insert{},
 		&LeftDelete{},
 		&RightDelete{},

--- a/insdel.go
+++ b/insdel.go
@@ -34,14 +34,14 @@ type (
 	}
 
 	// DeleteWord Command deletes one word to right or left
-	// depending on forward variable
+	// depending on forward variable.
 	DeleteWord struct {
 		backend.DefaultCommand
 		Forward bool
 	}
 )
 
-// Run will execute the Insert command
+// Run executes the Insert command.
 func (c *Insert) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -55,7 +55,7 @@ func (c *Insert) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run executes the LeftDelete command
+// Run executes the LeftDelete command.
 func (c *LeftDelete) Run(v *backend.View, e *backend.Edit) error {
 	trimSpace := false
 	tabSize := 4
@@ -102,7 +102,7 @@ func (c *LeftDelete) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the RightDelete command
+// Run executes the RightDelete command.
 func (c *RightDelete) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	hasNonEmpty := sel.HasNonEmpty()
@@ -125,7 +125,7 @@ func (c *RightDelete) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the DeleteWord command
+// Run executes the DeleteWord command.
 func (c *DeleteWord) Run(v *backend.View, e *backend.Edit) error {
 	var class int
 	if c.Forward {

--- a/insdel_test.go
+++ b/insdel_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 func TestBasic(t *testing.T) {
@@ -18,7 +18,7 @@ func TestBasic(t *testing.T) {
 Test
 Goodbye world
 `
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -33,92 +33,92 @@ Goodbye world
 	v.EndEdit(e)
 
 	v.Sel().Clear()
-	v.Sel().Add(Region{11, 11})
-	v.Sel().Add(Region{16, 16})
-	v.Sel().Add(Region{30, 30})
+	v.Sel().Add(text.Region{11, 11})
+	v.Sel().Add(text.Region{16, 16})
+	v.Sel().Add(text.Region{30, 30})
 	ed.CommandHandler().RunTextCommand(v, "left_delete", nil)
-	if v.Substr(Region{0, v.Size()}) != `Hello worl
+	if v.Substr(text.Region{0, v.Size()}) != `Hello worl
 Tes
 Goodbye worl
 ` {
-		t.Error(v.Substr(Region{0, v.Size()}))
+		t.Error(v.Substr(text.Region{0, v.Size()}))
 	}
-	ed.CommandHandler().RunTextCommand(v, "insert", Args{"characters": "a"})
-	if d := v.Substr(Region{0, v.Size()}); d != "Hello worla\nTesa\nGoodbye worla\n" {
-		lines := strings.Split(v.Substr(Region{0, v.Size()}), "\n")
+	ed.CommandHandler().RunTextCommand(v, "insert", backend.Args{"characters": "a"})
+	if d := v.Substr(text.Region{0, v.Size()}); d != "Hello worla\nTesa\nGoodbye worla\n" {
+		lines := strings.Split(v.Substr(text.Region{0, v.Size()}), "\n")
 		for _, l := range lines {
 			t.Errorf("%d: '%s'", len(l), l)
 		}
 	}
 
 	v.Settings().Set("translate_tabs_to_spaces", true)
-	ed.CommandHandler().RunTextCommand(v, "insert", Args{"characters": "\t"})
-	if v.Substr(Region{0, v.Size()}) != "Hello worla \nTesa    \nGoodbye worla   \n" {
-		lines := strings.Split(v.Substr(Region{0, v.Size()}), "\n")
+	ed.CommandHandler().RunTextCommand(v, "insert", backend.Args{"characters": "\t"})
+	if v.Substr(text.Region{0, v.Size()}) != "Hello worla \nTesa    \nGoodbye worla   \n" {
+		lines := strings.Split(v.Substr(text.Region{0, v.Size()}), "\n")
 		for _, l := range lines {
 			t.Errorf("%d: '%s'", len(l), l)
 		}
 	}
 	ed.CommandHandler().RunTextCommand(v, "left_delete", nil)
-	if d := v.Substr(Region{0, v.Size()}); d != "Hello worla\nTesa\nGoodbye worla\n" {
-		lines := strings.Split(v.Substr(Region{0, v.Size()}), "\n")
+	if d := v.Substr(text.Region{0, v.Size()}); d != "Hello worla\nTesa\nGoodbye worla\n" {
+		lines := strings.Split(v.Substr(text.Region{0, v.Size()}), "\n")
 		for _, l := range lines {
 			t.Errorf("%d: '%s'", len(l), l)
 		}
 	}
 
 	ed.CommandHandler().RunTextCommand(v, "left_delete", nil)
-	if d := v.Substr(Region{0, v.Size()}); d != "Hello worl\nTes\nGoodbye worl\n" {
-		lines := strings.Split(v.Substr(Region{0, v.Size()}), "\n")
+	if d := v.Substr(text.Region{0, v.Size()}); d != "Hello worl\nTes\nGoodbye worl\n" {
+		lines := strings.Split(v.Substr(text.Region{0, v.Size()}), "\n")
 		for _, l := range lines {
 			t.Errorf("%d: '%s'", len(l), l)
 		}
 	}
 
-	ed.CommandHandler().RunTextCommand(v, "insert", Args{"characters": "\t"})
-	if d := v.Substr(Region{0, v.Size()}); d != "Hello worl  \nTes \nGoodbye worl    \n" {
-		lines := strings.Split(v.Substr(Region{0, v.Size()}), "\n")
+	ed.CommandHandler().RunTextCommand(v, "insert", backend.Args{"characters": "\t"})
+	if d := v.Substr(text.Region{0, v.Size()}); d != "Hello worl  \nTes \nGoodbye worl    \n" {
+		lines := strings.Split(v.Substr(text.Region{0, v.Size()}), "\n")
 		for _, l := range lines {
 			t.Errorf("%d: '%s'", len(l), l)
 		}
 	}
 
 	ed.CommandHandler().RunTextCommand(v, "left_delete", nil)
-	if v.Substr(Region{0, v.Size()}) != "Hello worl\nTes\nGoodbye worl\n" {
-		lines := strings.Split(v.Substr(Region{0, v.Size()}), "\n")
+	if v.Substr(text.Region{0, v.Size()}) != "Hello worl\nTes\nGoodbye worl\n" {
+		lines := strings.Split(v.Substr(text.Region{0, v.Size()}), "\n")
 		for _, l := range lines {
 			t.Errorf("%d: '%s'", len(l), l)
 		}
 	}
 
 	edit := v.BeginEdit()
-	v.Erase(edit, Region{0, v.Size()})
+	v.Erase(edit, text.Region{0, v.Size()})
 	v.Insert(edit, 0, "€þıœəßðĸʒ×ŋµåäö𝄞")
 	v.EndEdit(edit)
 	orig := "€þıœəßðĸʒ×ŋµåäö𝄞"
-	if d := v.Substr(Region{0, v.Size()}); d != orig {
+	if d := v.Substr(text.Region{0, v.Size()}); d != orig {
 		t.Errorf("%s\n\t%v\n\t%v", d, []byte(d), []byte(orig))
 	}
 
 	v.Sel().Clear()
-	v.Sel().Add(Region{3, 3})
-	v.Sel().Add(Region{6, 6})
-	v.Sel().Add(Region{9, 9})
+	v.Sel().Add(text.Region{3, 3})
+	v.Sel().Add(text.Region{6, 6})
+	v.Sel().Add(text.Region{9, 9})
 	ed.CommandHandler().RunTextCommand(v, "left_delete", nil)
 	exp := "€þœəðĸ×ŋµåäö𝄞"
-	if d := v.Substr(Region{0, v.Size()}); d != exp {
+	if d := v.Substr(text.Region{0, v.Size()}); d != exp {
 		t.Errorf("%s\n\t%v\n\t%v", d, []byte(d), []byte(exp))
 	}
 }
 
 type deleteTest struct {
-	in, out []Region
+	in, out []text.Region
 	text    string
 	ins     string
 }
 
 func runDeleteTest(command string, tests *[]deleteTest, t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 
 	for i, test := range *tests {
@@ -136,13 +136,13 @@ func runDeleteTest(command string, tests *[]deleteTest, t *testing.T) {
 		for _, r := range test.in {
 			v.Sel().Add(r)
 		}
-		var s2 RegionSet
+		var s2 text.RegionSet
 		for _, r := range test.out {
 			s2.Add(r)
 		}
 
 		ed.CommandHandler().RunTextCommand(v, command, nil)
-		if d := v.Substr(Region{0, v.Size()}); d != test.text {
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.text {
 			t.Errorf("Test %02d: Expected %s, but got %s", i, test.text, d)
 		} else if !reflect.DeepEqual(*v.Sel(), s2) {
 			t.Errorf("Test %02d: Expected %v, but have %v", i, s2, v.Sel())
@@ -154,32 +154,32 @@ func runDeleteTest(command string, tests *[]deleteTest, t *testing.T) {
 func TestLeftDelete(t *testing.T) {
 	tests := []deleteTest{
 		{
-			[]Region{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
-			[]Region{{0, 0}},
+			[]text.Region{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+			[]text.Region{{0, 0}},
 			"5678",
 			"12345678",
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {5, 5}, {7, 7}},
-			[]Region{{0, 0}, {1, 1}, {2, 2}, {3, 3}},
+			[]text.Region{{1, 1}, {3, 3}, {5, 5}, {7, 7}},
+			[]text.Region{{0, 0}, {1, 1}, {2, 2}, {3, 3}},
 			"2468",
 			"12345678",
 		},
 		{
-			[]Region{{1, 3}},
-			[]Region{{1, 1}},
+			[]text.Region{{1, 3}},
+			[]text.Region{{1, 1}},
 			"145678",
 			"12345678",
 		},
 		{
-			[]Region{{3, 1}},
-			[]Region{{1, 1}},
+			[]text.Region{{3, 1}},
+			[]text.Region{{1, 1}},
 			"145678",
 			"12345678",
 		},
 		{
-			[]Region{{100, 5}},
-			[]Region{{93, 5}},
+			[]text.Region{{100, 5}},
+			[]text.Region{{93, 5}},
 			"abc\nd",
 			"abc\ndef\nghi\n",
 		}, // Yes, this is indeed what ST3 does too.
@@ -191,26 +191,26 @@ func TestLeftDelete(t *testing.T) {
 func TestRightDelete(t *testing.T) {
 	tests := []deleteTest{
 		{
-			[]Region{{0, 0}, {1, 1}, {2, 2}, {3, 3}},
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}, {1, 1}, {2, 2}, {3, 3}},
+			[]text.Region{{0, 0}},
 			"5678",
 			"12345678",
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {5, 5}, {7, 7}},
-			[]Region{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+			[]text.Region{{1, 1}, {3, 3}, {5, 5}, {7, 7}},
+			[]text.Region{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
 			"1357",
 			"12345678",
 		},
 		{
-			[]Region{{1, 3}},
-			[]Region{{1, 1}},
+			[]text.Region{{1, 3}},
+			[]text.Region{{1, 1}},
 			"145678",
 			"12345678",
 		},
 		{
-			[]Region{{3, 1}},
-			[]Region{{1, 1}},
+			[]text.Region{{3, 1}},
+			[]text.Region{{1, 1}},
 			"145678",
 			"12345678",
 		},
@@ -220,7 +220,7 @@ func TestRightDelete(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ch := ed.CommandHandler()
 	w := ed.NewWindow()
 	defer w.Close()
@@ -236,30 +236,30 @@ func TestInsert(t *testing.T) {
 	v.EndEdit(e)
 
 	type Test struct {
-		in   []Region
+		in   []text.Region
 		data string
 		expd string
-		expr []Region
+		expr []text.Region
 	}
 
 	tests := []Test{
 		{
-			[]Region{{1, 1}, {3, 3}, {6, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {6, 6}},
 			"a",
 			"Haelalo aWorld!\nTest123123\nAbrakadabra\n",
-			[]Region{{2, 2}, {5, 5}, {9, 9}},
+			[]text.Region{{2, 2}, {5, 5}, {9, 9}},
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {6, 9}},
+			[]text.Region{{1, 1}, {3, 3}, {6, 9}},
 			"a",
 			"Haelalo ald!\nTest123123\nAbrakadabra\n",
-			[]Region{{2, 2}, {5, 5}, {9, 9}},
+			[]text.Region{{2, 2}, {5, 5}, {9, 9}},
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {6, 9}},
+			[]text.Region{{1, 1}, {3, 3}, {6, 9}},
 			"€þıœəßðĸʒ×ŋµåäö𝄞",
 			"H€þıœəßðĸʒ×ŋµåäö𝄞el€þıœəßðĸʒ×ŋµåäö𝄞lo €þıœəßðĸʒ×ŋµåäö𝄞ld!\nTest123123\nAbrakadabra\n",
-			[]Region{{17, 17}, {35, 35}, {54, 54}},
+			[]text.Region{{17, 17}, {35, 35}, {54, 54}},
 		},
 	}
 
@@ -268,8 +268,8 @@ func TestInsert(t *testing.T) {
 		for _, r := range test.in {
 			v.Sel().Add(r)
 		}
-		ed.CommandHandler().RunTextCommand(v, "insert", Args{"characters": test.data})
-		if d := v.Substr(Region{0, v.Size()}); d != test.expd {
+		ed.CommandHandler().RunTextCommand(v, "insert", backend.Args{"characters": test.data})
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expd {
 			t.Errorf("Insert test %d failed: %s", i, d)
 		}
 		if sr := v.Sel().Regions(); !reflect.DeepEqual(sr, test.expr) {
@@ -282,37 +282,37 @@ func TestInsert(t *testing.T) {
 func TestDeleteWord(t *testing.T) {
 	tests := []struct {
 		text    string
-		sel     []Region
+		sel     []text.Region
 		forward bool
 		expect  string
 	}{
 		{
 			"word",
-			[]Region{{4, 4}},
+			[]text.Region{{4, 4}},
 			false,
 			"",
 		},
 		{
 			"'(}[word",
-			[]Region{{7, 7}, {4, 4}},
+			[]text.Region{{7, 7}, {4, 4}},
 			false,
 			"d",
 		},
 		{
 			"testing forwar|d\ndelete word",
-			[]Region{{0, 2}, {11, 11}, {16, 16}},
+			[]text.Region{{0, 2}, {11, 11}, {16, 16}},
 			true,
 			"sting for|ddelete word",
 		},
 		{
 			"simple 	test 	on outside",
-			[]Region{{-1, -1}, {6, 6}, {13, 13}, {54, 33}, {31, 31}},
+			[]text.Region{{-1, -1}, {6, 6}, {13, 13}, {54, 33}, {31, 31}},
 			true,
 			"simpletest  outside",
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -330,8 +330,8 @@ func TestDeleteWord(t *testing.T) {
 		v.Sel().Clear()
 		v.Sel().AddAll(test.sel)
 
-		ed.CommandHandler().RunTextCommand(v, "delete_word", Args{"forward": test.forward})
-		if d := v.Substr(Region{0, v.Size()}); d != test.expect {
+		ed.CommandHandler().RunTextCommand(v, "delete_word", backend.Args{"forward": test.forward})
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expect {
 			t.Errorf("Test %d:\nExcepted: '%s' but got: '%s'", i, test.expect, d)
 		}
 	}

--- a/line.go
+++ b/line.go
@@ -13,12 +13,12 @@ import (
 
 type (
 	// JoinLines removes every new line in the
-	// selections and the first new line after
+	// selections and the first new line after.
 	JoinLines struct {
 		backend.DefaultCommand
 	}
 
-	//SelectLines command will select the lines
+	//SelectLines command will select the lines.
 	SelectLines struct {
 		backend.DefaultCommand
 		Forward bool
@@ -26,25 +26,25 @@ type (
 
 	//SwapLineUp command will swap the current line
 	//with the line immediately above it until the
-	//line reaches the top
+	//line reaches the top.
 	SwapLineUp struct {
 		backend.DefaultCommand
 	}
 
 	//SwapLineDown command will swap the current line
-	//with the line immediately below it until it reaches bottom
+	//with the line immediately below it until it reaches bottom.
 	SwapLineDown struct {
 		backend.DefaultCommand
 	}
 
 	//SplitSelectionIntoLines will split the current
-	//selection into lines
+	//selection into lines.
 	SplitSelectionIntoLines struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run executes the JoinLines command
+//Run executes the JoinLines command.
 func (c *JoinLines) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -81,7 +81,7 @@ func (c *JoinLines) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the SwapLineUp command
+//Run executes the SwapLineUp command.
 func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -101,7 +101,7 @@ func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the SwapLineDown command
+//Run executes the SwapLineDown command.
 func (c *SwapLineDown) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -121,7 +121,7 @@ func (c *SwapLineDown) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the SelectLines command
+//Run executes the SelectLines command.
 func (c *SelectLines) Run(v *backend.View, e *backend.Edit) error {
 	var (
 		rs      []text.Region
@@ -156,6 +156,7 @@ func (c *SelectLines) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
+// Run executes the SplitSelectionIntoLines command
 func (c *SplitSelectionIntoLines) Run(v *backend.View, e *backend.Edit) error {
 	var rs []text.Region
 

--- a/line.go
+++ b/line.go
@@ -18,33 +18,31 @@ type (
 		backend.DefaultCommand
 	}
 
-	//SelectLines command will select the lines.
+	// SelectLines makes the selection fill the lines
+	// covered by it currently
 	SelectLines struct {
 		backend.DefaultCommand
 		Forward bool
 	}
-
-	//SwapLineUp command will swap the current line
-	//with the line immediately above it until the
-	//line reaches the top.
+	// SwapLineUp swaps the currently selected lines with the ones above
 	SwapLineUp struct {
 		backend.DefaultCommand
 	}
 
-	//SwapLineDown command will swap the current line
-	//with the line immediately below it until it reaches bottom.
+	// SwapLineDown swaps the currently selected
+	// lines with the ones below
 	SwapLineDown struct {
 		backend.DefaultCommand
 	}
 
-	//SplitSelectionIntoLines will split the current
-	//selection into lines.
+	// SplitSelectionIntoLines will split the current
+	// selection into lines.
 	SplitSelectionIntoLines struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run executes the JoinLines command.
+// Run executes the JoinLines command.
 func (c *JoinLines) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -81,7 +79,7 @@ func (c *JoinLines) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the SwapLineUp command.
+// Run executes the SwapLineUp command.
 func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -101,7 +99,7 @@ func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the SwapLineDown command.
+// Run executes the SwapLineDown command.
 func (c *SwapLineDown) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -121,7 +119,7 @@ func (c *SwapLineDown) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the SelectLines command.
+// Run executes the SelectLines command.
 func (c *SelectLines) Run(v *backend.View, e *backend.Edit) error {
 	var (
 		rs      []text.Region

--- a/line.go
+++ b/line.go
@@ -7,36 +7,45 @@ package commands
 import (
 	"strings"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type (
 	// JoinLines removes every new line in the
 	// selections and the first new line after
 	JoinLines struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//SelectLines command will select the lines
 	SelectLines struct {
-		DefaultCommand
+		backend.DefaultCommand
 		Forward bool
 	}
 
+	//SwapLineUp command will swap the current line
+	//with the line immediately above it until the
+	//line reaches the top
 	SwapLineUp struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//SwapLineDown command will swap the current line
+	//with the line immediately below it until it reaches bottom
 	SwapLineDown struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//SplitSelectionIntoLines will split the current
+	//selection into lines
 	SplitSelectionIntoLines struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *JoinLines) Run(v *View, e *Edit) error {
+//Run executes the JoinLines command
+func (c *JoinLines) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
@@ -72,14 +81,15 @@ func (c *JoinLines) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SwapLineUp) Run(v *View, e *Edit) error {
+//Run executes the SwapLineUp command
+func (c *SwapLineUp) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
 		// Expand to all lines under selection
 		fline := v.Line(r.Begin())
 		lline := v.Line(r.End())
-		r = Region{fline.Begin(), lline.End()}
+		r = text.Region{fline.Begin(), lline.End()}
 		t := v.Substr(r)
 		// Select line before region
 		bline := v.Line(r.Begin() - 1)
@@ -91,14 +101,15 @@ func (c *SwapLineUp) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SwapLineDown) Run(v *View, e *Edit) error {
+//Run executes the SwapLineDown command
+func (c *SwapLineDown) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
 		r := sel.Get(i)
 		// Expand to all lines under selection
 		fline := v.Line(r.Begin())
 		lline := v.Line(r.End())
-		r = Region{fline.Begin(), lline.End()}
+		r = text.Region{fline.Begin(), lline.End()}
 		t := v.Substr(r)
 		// Select line before region
 		nline := v.Line(r.End() + 1)
@@ -110,10 +121,11 @@ func (c *SwapLineDown) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SelectLines) Run(v *View, e *Edit) error {
+//Run executes the SelectLines command
+func (c *SelectLines) Run(v *backend.View, e *backend.Edit) error {
 	var (
-		rs      []Region
-		line, l Region
+		rs      []text.Region
+		line, l text.Region
 		d       int
 	)
 
@@ -134,9 +146,9 @@ func (c *SelectLines) Run(v *View, e *Edit) error {
 		// Put new region at the exact distance
 		// If not put region at the end of the next|before line
 		if l.Size() < d {
-			rs = append(rs, Region{l.End(), l.End()})
+			rs = append(rs, text.Region{l.End(), l.End()})
 		} else {
-			rs = append(rs, Region{l.Begin() + d, l.Begin() + d})
+			rs = append(rs, text.Region{l.Begin() + d, l.Begin() + d})
 		}
 	}
 	v.Sel().AddAll(rs)
@@ -144,8 +156,8 @@ func (c *SelectLines) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SplitSelectionIntoLines) Run(v *View, e *Edit) error {
-	var rs []Region
+func (c *SplitSelectionIntoLines) Run(v *backend.View, e *backend.Edit) error {
+	var rs []text.Region
 
 	sel := v.Sel()
 	for i := 0; i < sel.Len(); i++ {
@@ -167,7 +179,7 @@ func (c *SplitSelectionIntoLines) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&JoinLines{},
 		&SelectLines{},
 		&SwapLineUp{},

--- a/line_test.go
+++ b/line_test.go
@@ -7,39 +7,39 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 func TestJoinLines(t *testing.T) {
 	tests := []struct {
 		text   string
-		sel    []Region
+		sel    []text.Region
 		expect string
 	}{
 		{
 			"a\n\t  bc",
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"a bc",
 		},
 		{
 			"abc\r\n\tde",
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			"abc de",
 		},
 		{
 			"testing \t\t\n join",
-			[]Region{{9, 8}},
+			[]text.Region{{9, 8}},
 			"testing join",
 		},
 		{
 			"test\n join\n command\n whith\n multiple\n regions",
-			[]Region{{2, 17}, {34, 40}},
+			[]text.Region{{2, 17}, {34, 40}},
 			"test join command whith\n multiple regions",
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -58,7 +58,7 @@ func TestJoinLines(t *testing.T) {
 		v.Sel().AddAll(test.sel)
 
 		ed.CommandHandler().RunTextCommand(v, "join_lines", nil)
-		if d := v.Substr(Region{0, v.Size()}); d != test.expect {
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expect {
 			t.Errorf("Test %d:\nExcepted: '%s'\nbut got: '%s'", i, test.expect, d)
 		}
 	}
@@ -67,43 +67,43 @@ func TestJoinLines(t *testing.T) {
 func TestSelectLines(t *testing.T) {
 	tests := []struct {
 		text    string
-		sel     []Region
+		sel     []text.Region
 		forward bool
-		expect  []Region
+		expect  []text.Region
 	}{
 		{
 			"abc\ndefg",
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			true,
-			[]Region{{1, 1}, {5, 5}},
+			[]text.Region{{1, 1}, {5, 5}},
 		},
 		{
 			"abcde\nfg",
-			[]Region{{4, 4}},
+			[]text.Region{{4, 4}},
 			true,
-			[]Region{{4, 4}, {8, 8}},
+			[]text.Region{{4, 4}, {8, 8}},
 		},
 		{
 			"Testing select lines command\nin\nlime text",
-			[]Region{{8, 14}, {30, 30}},
+			[]text.Region{{8, 14}, {30, 30}},
 			true,
-			[]Region{{8, 14}, {30, 30}, {31, 31}, {33, 33}},
+			[]text.Region{{8, 14}, {30, 30}, {31, 31}, {33, 33}},
 		},
 		{
 			"abc\n\ndefg",
-			[]Region{{6, 6}},
+			[]text.Region{{6, 6}},
 			false,
-			[]Region{{6, 6}, {4, 4}},
+			[]text.Region{{6, 6}, {4, 4}},
 		},
 		{
 			"Testing select lines command\nin\nlime text",
-			[]Region{{30, 36}, {29, 29}},
+			[]text.Region{{30, 36}, {29, 29}},
 			false,
-			[]Region{{30, 36}, {29, 29}, {0, 0}, {1, 1}},
+			[]text.Region{{30, 36}, {29, 29}, {0, 0}, {1, 1}},
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -121,7 +121,7 @@ func TestSelectLines(t *testing.T) {
 		v.Sel().Clear()
 		v.Sel().AddAll(test.sel)
 
-		ed.CommandHandler().RunTextCommand(v, "select_lines", Args{"forward": test.forward})
+		ed.CommandHandler().RunTextCommand(v, "select_lines", backend.Args{"forward": test.forward})
 		// Comparing regions
 		d := v.Sel()
 		if d.Len() != len(test.expect) {
@@ -148,19 +148,19 @@ func TestSelectLines(t *testing.T) {
 func TestSwapLine(t *testing.T) {
 	type SwapLineTest struct {
 		text   string
-		sel    []Region
+		sel    []text.Region
 		expect string
 	}
 
 	uptests := []SwapLineTest{
 		{
 			"a\nb",
-			[]Region{{2, 2}},
+			[]text.Region{{2, 2}},
 			"b\na",
 		},
 		{
 			"Testing swap line up\ncommand whit multiple\nregions selected\nTesting swap line up\ncommand whit multiple\nregions selected",
-			[]Region{{25, 53}, {86, 95}},
+			[]text.Region{{25, 53}, {86, 95}},
 			"command whit multiple\nregions selected\nTesting swap line up\ncommand whit multiple\nTesting swap line up\nregions selected",
 		},
 	}
@@ -168,17 +168,17 @@ func TestSwapLine(t *testing.T) {
 	dwtests := []SwapLineTest{
 		{
 			"a\nb",
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"b\na",
 		},
 		{
 			"Testing swap line up\ncommand whit multiple\nregions selected\nTesting swap line up\ncommand whit multiple\nregions selected",
-			[]Region{{25, 53}, {86, 95}},
+			[]text.Region{{25, 53}, {86, 95}},
 			"Testing swap line up\nTesting swap line up\ncommand whit multiple\nregions selected\nregions selected\ncommand whit multiple",
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -197,7 +197,7 @@ func TestSwapLine(t *testing.T) {
 		v.Sel().AddAll(test.sel)
 
 		ed.CommandHandler().RunTextCommand(v, "swap_line_up", nil)
-		if d := v.Substr(Region{0, v.Size()}); d != test.expect {
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expect {
 			t.Errorf("Test %d:\nExcepted: '%s'\nbut got: '%s'", i, test.expect, d)
 		}
 	}
@@ -217,7 +217,7 @@ func TestSwapLine(t *testing.T) {
 		v.Sel().AddAll(test.sel)
 
 		ed.CommandHandler().RunTextCommand(v, "swap_line_down", nil)
-		if d := v.Substr(Region{0, v.Size()}); d != test.expect {
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expect {
 			t.Errorf("Test %d:\nExcepted: '%s'\nbut got: '%s'", i, test.expect, d)
 		}
 	}
@@ -226,27 +226,27 @@ func TestSwapLine(t *testing.T) {
 func TestSplitToLines(t *testing.T) {
 	tests := []struct {
 		text   string
-		sel    []Region
-		expect []Region
+		sel    []text.Region
+		expect []text.Region
 	}{
 		{
 			"ab\ncd\nef",
-			[]Region{{4, 7}},
-			[]Region{{4, 5}, {6, 7}},
+			[]text.Region{{4, 7}},
+			[]text.Region{{4, 5}, {6, 7}},
 		},
 		{
 			"ab\ncd\nef",
-			[]Region{{0, 8}},
-			[]Region{{0, 2}, {3, 5}, {6, 8}},
+			[]text.Region{{0, 8}},
+			[]text.Region{{0, 2}, {3, 5}, {6, 8}},
 		},
 		{
 			"ab\ncd\nef",
-			[]Region{{0, 4}, {4, 7}},
-			[]Region{{0, 2}, {3, 4}, {4, 5}, {6, 7}},
+			[]text.Region{{0, 4}, {4, 7}},
+			[]text.Region{{0, 2}, {3, 4}, {4, 5}, {6, 7}},
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 

--- a/move.go
+++ b/move.go
@@ -14,83 +14,83 @@ import (
 )
 
 type (
-	// Move Command moves the current selection
+	// Move Command moves the current selection.
 	Move struct {
 		backend.DefaultCommand
-		// Specifies the type of "move" operation
+		// Specifies the type of "move" operation.
 		By MoveByType
-		// Whether the current selection should be extended or not
+		// Whether the current selection should be extended or not.
 		Extend bool
-		// Whether to move forward or backwards
+		// Whether to move forward or backwards.
 		Forward bool
-		// Used together with By=Stops, extends "word_separators" defined by settings
+		// Used together with By=Stops, extends "word_separators" defined by settings.
 		Separators string
-		// Used together with By=Stops, go to word begin
+		// Used together with By=Stops, go to word begin.
 		WordBegin bool
-		// Used together with By=Stops, go to word end
+		// Used together with By=Stops, go to word end.
 		WordEnd bool
-		// Used together with By=Stops, go to punctuation begin
+		// Used together with By=Stops, go to punctuation begin.
 		PunctBegin bool
-		// Used together with By=Stops, go to punctuation end
+		// Used together with By=Stops, go to punctuation end.
 		PunctEnd bool
-		// Used together with By=Stops, go to an empty line
+		// Used together with By=Stops, go to an empty line.
 		EmptyLine bool
 		// Used together with By=Stops, TODO: ???
 		ClipToLine bool
 	}
 
-	// MoveByType Specifies the type of "move" operation
+	// MoveByType Specifies the type of "move" operation.
 	MoveByType int
 
-	// MoveToType Specifies the type of "move_to" operation to perform
+	// MoveToType Specifies the type of "move_to" operation to perform.
 	MoveToType int
 
-	// MoveTo Command moves or extends the current selection to the specified location
+	// MoveTo Command moves or extends the current selection to the specified location.
 	MoveTo struct {
 		backend.DefaultCommand
-		// The type of "move_to" operation to perform
+		// The type of "move_to" operation to perform.
 		To MoveToType
-		// Whether the current selection should be extended or not
+		// Whether the current selection should be extended or not.
 		Extend bool
 	}
 
-	// ScrollLines Command moves the viewpoint "Amount" lines from the current location
+	// ScrollLines Command moves the viewpoint "Amount" lines from the current location.
 	ScrollLines struct {
 		backend.BypassUndoCommand
-		// The number of lines to scroll (positive or negative direction)
+		// The number of lines to scroll (positive or negative direction).
 		Amount int
 	}
 )
 
 const (
-	// BOL is Beginning of line
+	// BOL is Beginning of line.
 	BOL MoveToType = iota
 	// EOL is End of line
 	EOL
-	//BOF is Beginning of file
+	//BOF is Beginning of file.
 	BOF
-	// EOF is End of file
+	// EOF is End of file.
 	EOF
-	// Brackets >-> Current level close bracket
+	// Brackets >-> Current level close bracket.
 	Brackets
 )
 
 const (
-	// Characters by Characters
+	// Characters by Characters.
 	Characters MoveByType = iota
-	// Stops will move by Stops (TODO(.): what exactly is a stop?)
+	// Stops will move by Stops (TODO(.): what exactly is a stop?).
 	Stops
-	// Lines will move by Lines
+	// Lines will move by Lines.
 	Lines
-	//Words will move by Words
+	//Words will move by Words.
 	Words
-	//WordEnds will move by Word Ends
+	//WordEnds will move by Word Ends.
 	WordEnds
-	//SubWords will move by Sub Words
+	//SubWords will move by Sub Words.
 	SubWords
-	// SubWordEnds will Move by Sub Word Ends
+	// SubWordEnds will Move by Sub Word Ends.
 	SubWordEnds
-	//Pages will move by Page
+	//Pages will move by Page.
 	Pages
 )
 
@@ -105,7 +105,7 @@ func moveAction(v *backend.View, extend bool, transform func(r text.Region) int)
 		} else if r[i].B > bs {
 			// Yes > the size, and not size-1 because the cursor being at "size"
 			// is the position it will be at when we are appending
-			// to the buffer
+			// to the buffer.
 			r[i].B = bs
 		}
 
@@ -136,7 +136,7 @@ func (mt *MoveToType) Set(v interface{}) error {
 	return nil
 }
 
-// Run will execute the MoveTo command
+// Run executes the MoveTo command.
 func (c *MoveTo) Run(v *backend.View, e *backend.Edit) error {
 	switch c.To {
 	case EOL:
@@ -226,7 +226,7 @@ func (c *MoveTo) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Set will set what type of move it is
+// Set the type of move.
 func (m *MoveByType) Set(v interface{}) error {
 	switch by := v.(string); by {
 	case "lines":
@@ -251,7 +251,7 @@ func (m *MoveByType) Set(v interface{}) error {
 	return nil
 }
 
-// Run will execute the Move command
+// Run executes the Move command.
 func (c *Move) Run(v *backend.View, e *backend.Edit) error {
 	p := util.Prof.Enter("move.run.action")
 	defer p.Exit()
@@ -342,7 +342,7 @@ func (c *Move) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Default returns the default seprators
+// Default returns the default seprators.
 func (c *Move) Default(key string) interface{} {
 	if key == "separators" {
 		return backend.DEFAULT_SEPARATORS
@@ -376,7 +376,7 @@ func reverse(s string) string {
 	return string(r)
 }
 
-// Run will execute the ScrollLines command
+// Run executes the ScrollLines command.
 func (c *ScrollLines) Run(v *backend.View, e *backend.Edit) error {
 	ed := backend.GetEditor()
 	fe := ed.Frontend()

--- a/move.go
+++ b/move.go
@@ -8,15 +8,15 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 	"github.com/limetext/text"
 	"github.com/limetext/util"
 )
 
 type (
-	// The MoveCommand moves the current selection
+	// Move Command moves the current selection
 	Move struct {
-		DefaultCommand
+		backend.DefaultCommand
 		// Specifies the type of "move" operation
 		By MoveByType
 		// Whether the current selection should be extended or not
@@ -39,62 +39,62 @@ type (
 		ClipToLine bool
 	}
 
-	// Specifies the type of "move" operation
+	//MoveByType Specifies the type of "move" operation
 	MoveByType int
 
-	// Specifies the type of "move_to" operation to perform
+	//MoveToType Specifies the type of "move_to" operation to perform
 	MoveToType int
 
-	// The MoveToCommand moves or extends the current selection to the specified location
+	// MoveTo Command moves or extends the current selection to the specified location
 	MoveTo struct {
-		DefaultCommand
+		backend.DefaultCommand
 		// The type of "move_to" operation to perform
 		To MoveToType
 		// Whether the current selection should be extended or not
 		Extend bool
 	}
 
-	// The ScrollLinesCommand moves the viewpoint "Amount" lines from the current location
+	// ScrollLines Command moves the viewpoint "Amount" lines from the current location
 	ScrollLines struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 		// The number of lines to scroll (positive or negative direction)
 		Amount int
 	}
 )
 
 const (
-	// Beginning of line
+	// BOL is Beginning of line
 	BOL MoveToType = iota
-	// End of line
+	// EOL is End of line
 	EOL
-	// Beginning of file
+	//BOF is Beginning of file
 	BOF
-	// End of file
+	// EOF is End of file
 	EOF
-	// Current level close bracket
+	// Brackets >-> Current level close bracket
 	Brackets
 )
 
 const (
-	// Move by Characters
+	// Characters by Characters
 	Characters MoveByType = iota
-	// Move by Stops (TODO(.): what exactly is a stop?)
+	// Stops will move by Stops (TODO(.): what exactly is a stop?)
 	Stops
-	// Move by Lines
+	// Lines will move by Lines
 	Lines
-	// Move by Words
+	//Words will move by Words
 	Words
-	// Move by Word Ends
+	//WordEnds will move by Word Ends
 	WordEnds
-	// Move by Sub Words
+	//SubWords will move by Sub Words
 	SubWords
-	// Move by Sub Word Ends
+	// SubWordEnds will Move by Sub Word Ends
 	SubWordEnds
-	// Move by Page
+	//Pages will move by Page
 	Pages
 )
 
-func move_action(v *View, extend bool, transform func(r text.Region) int) {
+func moveAction(v *backend.View, extend bool, transform func(r text.Region) int) {
 	sel := v.Sel()
 	r := sel.Regions()
 	bs := v.Size()
@@ -117,6 +117,7 @@ func move_action(v *View, extend bool, transform func(r text.Region) int) {
 	sel.AddAll(r)
 }
 
+//Set will define the type of move
 func (mt *MoveToType) Set(v interface{}) error {
 	switch to := v.(string); to {
 	case "eol":
@@ -135,28 +136,29 @@ func (mt *MoveToType) Set(v interface{}) error {
 	return nil
 }
 
-func (c *MoveTo) Run(v *View, e *Edit) error {
+//Run will execute the MoveTo command
+func (c *MoveTo) Run(v *backend.View, e *backend.Edit) error {
 	switch c.To {
 	case EOL:
-		move_action(v, c.Extend, func(r text.Region) int {
+		moveAction(v, c.Extend, func(r text.Region) int {
 			line := v.Line(r.B)
 			return line.B
 		})
 	case BOL:
-		move_action(v, c.Extend, func(r text.Region) int {
+		moveAction(v, c.Extend, func(r text.Region) int {
 			line := v.Line(r.B)
 			return line.A
 		})
 	case BOF:
-		move_action(v, c.Extend, func(r text.Region) int {
+		moveAction(v, c.Extend, func(r text.Region) int {
 			return 0
 		})
 	case EOF:
-		move_action(v, c.Extend, func(r text.Region) int {
+		moveAction(v, c.Extend, func(r text.Region) int {
 			return v.Size()
 		})
 	case Brackets:
-		move_action(v, c.Extend, func(r text.Region) (pos int) {
+		moveAction(v, c.Extend, func(r text.Region) (pos int) {
 			var (
 				of          int
 				co          = 1
@@ -224,6 +226,7 @@ func (c *MoveTo) Run(v *View, e *Edit) error {
 	return nil
 }
 
+//Run will execute the MoveByType command
 func (m *MoveByType) Set(v interface{}) error {
 	switch by := v.(string); by {
 	case "lines":
@@ -248,13 +251,14 @@ func (m *MoveByType) Set(v interface{}) error {
 	return nil
 }
 
-func (c *Move) Run(v *View, e *Edit) error {
+//Run will execute the Move command
+func (c *Move) Run(v *backend.View, e *backend.Edit) error {
 	p := util.Prof.Enter("move.run.action")
 	defer p.Exit()
 
 	switch c.By {
 	case Characters:
-		move_action(v, c.Extend, func(r text.Region) int {
+		moveAction(v, c.Extend, func(r text.Region) int {
 			dir := 1
 			if !c.Forward {
 				dir = -1
@@ -262,31 +266,31 @@ func (c *Move) Run(v *View, e *Edit) error {
 			return r.B + dir
 		})
 	case Stops:
-		move_action(v, c.Extend, func(in text.Region) int {
-			tmp := v.Settings().String("word_separators", DEFAULT_SEPARATORS)
+		moveAction(v, c.Extend, func(in text.Region) int {
+			tmp := v.Settings().String("word_separators", backend.DEFAULT_SEPARATORS)
 			defer v.Settings().Set("word_separators", tmp)
 			v.Settings().Set("word_separators", c.Separators)
 
 			classes := 0
 			if c.WordBegin {
-				classes |= CLASS_WORD_START
+				classes |= backend.CLASS_WORD_START
 			}
 			if c.WordEnd {
-				classes |= CLASS_WORD_END
+				classes |= backend.CLASS_WORD_END
 			}
 			if c.PunctBegin {
-				classes |= CLASS_PUNCTUATION_START
+				classes |= backend.CLASS_PUNCTUATION_START
 			}
 			if c.PunctEnd {
-				classes |= CLASS_PUNCTUATION_END
+				classes |= backend.CLASS_PUNCTUATION_END
 			}
 			if c.EmptyLine {
-				classes |= CLASS_EMPTY_LINE
+				classes |= backend.CLASS_EMPTY_LINE
 			}
 			return v.FindByClass(in.B, c.Forward, classes)
 		})
 	case Lines:
-		move_action(v, c.Extend, func(in text.Region) int {
+		moveAction(v, c.Extend, func(in text.Region) int {
 			r, col := v.RowCol(in.B)
 			fromLine := v.Line(v.TextPoint(r, 0))
 			if !c.Forward {
@@ -311,26 +315,26 @@ func (c *Move) Run(v *View, e *Edit) error {
 			return v.TextPoint(r, col)
 		})
 	case Words:
-		move_action(v, c.Extend, func(in text.Region) int {
-			return v.FindByClass(in.B, c.Forward, CLASS_WORD_START|
-				CLASS_LINE_END|CLASS_LINE_START)
+		moveAction(v, c.Extend, func(in text.Region) int {
+			return v.FindByClass(in.B, c.Forward, backend.CLASS_WORD_START|
+				backend.CLASS_LINE_END|backend.CLASS_LINE_START)
 		})
 	case WordEnds:
-		move_action(v, c.Extend, func(in text.Region) int {
-			return v.FindByClass(in.B, c.Forward, CLASS_WORD_END|
-				CLASS_LINE_END|CLASS_LINE_START)
+		moveAction(v, c.Extend, func(in text.Region) int {
+			return v.FindByClass(in.B, c.Forward, backend.CLASS_WORD_END|
+				backend.CLASS_LINE_END|backend.CLASS_LINE_START)
 		})
 	case SubWords:
-		move_action(v, c.Extend, func(in text.Region) int {
-			return v.FindByClass(in.B, c.Forward, CLASS_SUB_WORD_START|
-				CLASS_WORD_START|CLASS_PUNCTUATION_START|CLASS_LINE_END|
-				CLASS_LINE_START)
+		moveAction(v, c.Extend, func(in text.Region) int {
+			return v.FindByClass(in.B, c.Forward, backend.CLASS_SUB_WORD_START|
+				backend.CLASS_WORD_START|backend.CLASS_PUNCTUATION_START|backend.CLASS_LINE_END|
+				backend.CLASS_LINE_START)
 		})
 	case SubWordEnds:
-		move_action(v, c.Extend, func(in text.Region) int {
-			return v.FindByClass(in.B, c.Forward, CLASS_SUB_WORD_END|
-				CLASS_WORD_END|CLASS_PUNCTUATION_END|CLASS_LINE_END|
-				CLASS_LINE_START)
+		moveAction(v, c.Extend, func(in text.Region) int {
+			return v.FindByClass(in.B, c.Forward, backend.CLASS_SUB_WORD_END|
+				backend.CLASS_WORD_END|backend.CLASS_PUNCTUATION_END|backend.CLASS_LINE_END|
+				backend.CLASS_LINE_START)
 		})
 	case Pages:
 		// TODO: Should know how many lines does the frontend show in one page
@@ -338,9 +342,10 @@ func (c *Move) Run(v *View, e *Edit) error {
 	return nil
 }
 
+//Default returns the default seprators
 func (c *Move) Default(key string) interface{} {
 	if key == "separators" {
-		return DEFAULT_SEPARATORS
+		return backend.DEFAULT_SEPARATORS
 	}
 	return nil
 }
@@ -371,8 +376,9 @@ func reverse(s string) string {
 	return string(r)
 }
 
-func (c *ScrollLines) Run(v *View, e *Edit) error {
-	ed := GetEditor()
+//Run will execute the ScrollLines command
+func (c *ScrollLines) Run(v *backend.View, e *backend.Edit) error {
+	ed := backend.GetEditor()
 	fe := ed.Frontend()
 	vr := fe.VisibleRegion(v)
 	var r int
@@ -389,7 +395,7 @@ func (c *ScrollLines) Run(v *View, e *Edit) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Move{},
 		&MoveTo{},
 		&ScrollLines{},

--- a/move.go
+++ b/move.go
@@ -82,15 +82,15 @@ const (
 	Stops
 	// Lines will move by Lines.
 	Lines
-	//Words will move by Words.
+	// Words will move by Words.
 	Words
-	//WordEnds will move by Word Ends.
+	// WordEnds will move by Word Ends.
 	WordEnds
-	//SubWords will move by Sub Words.
+	// SubWords will move by Sub Words.
 	SubWords
 	// SubWordEnds will Move by Sub Word Ends.
 	SubWordEnds
-	//Pages will move by Page.
+	// Pages will move by Page.
 	Pages
 )
 

--- a/move.go
+++ b/move.go
@@ -39,10 +39,10 @@ type (
 		ClipToLine bool
 	}
 
-	//MoveByType Specifies the type of "move" operation
+	// MoveByType Specifies the type of "move" operation
 	MoveByType int
 
-	//MoveToType Specifies the type of "move_to" operation to perform
+	// MoveToType Specifies the type of "move_to" operation to perform
 	MoveToType int
 
 	// MoveTo Command moves or extends the current selection to the specified location
@@ -117,7 +117,7 @@ func moveAction(v *backend.View, extend bool, transform func(r text.Region) int)
 	sel.AddAll(r)
 }
 
-//Set will define the type of move
+// Set will define the type of move
 func (mt *MoveToType) Set(v interface{}) error {
 	switch to := v.(string); to {
 	case "eol":
@@ -136,7 +136,7 @@ func (mt *MoveToType) Set(v interface{}) error {
 	return nil
 }
 
-//Run will execute the MoveTo command
+// Run will execute the MoveTo command
 func (c *MoveTo) Run(v *backend.View, e *backend.Edit) error {
 	switch c.To {
 	case EOL:
@@ -226,7 +226,7 @@ func (c *MoveTo) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the MoveByType command
+// Set will set what type of move it is
 func (m *MoveByType) Set(v interface{}) error {
 	switch by := v.(string); by {
 	case "lines":
@@ -251,7 +251,7 @@ func (m *MoveByType) Set(v interface{}) error {
 	return nil
 }
 
-//Run will execute the Move command
+// Run will execute the Move command
 func (c *Move) Run(v *backend.View, e *backend.Edit) error {
 	p := util.Prof.Enter("move.run.action")
 	defer p.Exit()
@@ -342,7 +342,7 @@ func (c *Move) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Default returns the default seprators
+// Default returns the default seprators
 func (c *Move) Default(key string) interface{} {
 	if key == "separators" {
 		return backend.DEFAULT_SEPARATORS
@@ -376,7 +376,7 @@ func reverse(s string) string {
 	return string(r)
 }
 
-//Run will execute the ScrollLines command
+// Run will execute the ScrollLines command
 func (c *ScrollLines) Run(v *backend.View, e *backend.Edit) error {
 	ed := backend.GetEditor()
 	fe := ed.Frontend()

--- a/move_test.go
+++ b/move_test.go
@@ -8,21 +8,21 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type MoveTest struct {
-	in      []Region
+	in      []text.Region
 	by      string
 	extend  bool
 	forward bool
-	exp     []Region
-	args    Args
+	exp     []text.Region
+	args    backend.Args
 }
 
 func runMoveTest(tests []MoveTest, t *testing.T, text string) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	v := w.NewFile()
 
@@ -40,7 +40,7 @@ func runMoveTest(tests []MoveTest, t *testing.T, text string) {
 		for _, r := range test.in {
 			v.Sel().Add(r)
 		}
-		args := Args{"by": test.by, "extend": test.extend, "forward": test.forward}
+		args := backend.Args{"by": test.by, "extend": test.extend, "forward": test.forward}
 		if test.args != nil {
 			for k, v := range test.args {
 				args[k] = v
@@ -54,373 +54,373 @@ func runMoveTest(tests []MoveTest, t *testing.T, text string) {
 }
 
 func TestMove(t *testing.T) {
-	text := "Hello World!\nTest123123\nAbrakadabra\n"
+	inpuText := "Hello World!\nTest123123\nAbrakadabra\n"
 	tests := []MoveTest{
 		{
-			[]Region{{1, 1}, {3, 3}, {6, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {6, 6}},
 			"characters",
 			false,
 			true,
-			[]Region{{2, 2}, {4, 4}, {7, 7}},
+			[]text.Region{{2, 2}, {4, 4}, {7, 7}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {6, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {6, 6}},
 			"characters",
 			false,
 			false,
-			[]Region{{0, 0}, {2, 2}, {5, 5}},
+			[]text.Region{{0, 0}, {2, 2}, {5, 5}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {10, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {10, 6}},
 			"characters",
 			false,
 			true,
-			[]Region{{2, 2}, {4, 4}, {7, 7}},
+			[]text.Region{{2, 2}, {4, 4}, {7, 7}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {10, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {10, 6}},
 			"characters",
 			false,
 			false,
-			[]Region{{0, 0}, {2, 2}, {5, 5}},
+			[]text.Region{{0, 0}, {2, 2}, {5, 5}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {10, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {10, 6}},
 			"characters",
 			true,
 			true,
-			[]Region{{1, 2}, {3, 4}, {10, 7}},
+			[]text.Region{{1, 2}, {3, 4}, {10, 7}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}, {3, 3}, {10, 6}},
+			[]text.Region{{1, 1}, {3, 3}, {10, 6}},
 			"characters",
 			true,
 			false,
-			[]Region{{1, 0}, {3, 2}, {10, 5}},
+			[]text.Region{{1, 0}, {3, 2}, {10, 5}},
 			nil,
 		},
 		{
-			[]Region{{1, 3}, {3, 5}, {10, 7}},
+			[]text.Region{{1, 3}, {3, 5}, {10, 7}},
 			"characters",
 			true,
 			true,
-			[]Region{{1, 6}, {10, 8}},
+			[]text.Region{{1, 6}, {10, 8}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"stops",
 			true,
 			true,
-			[]Region{{1, 5}},
-			Args{"word_end": true},
+			[]text.Region{{1, 5}},
+			backend.Args{"word_end": true},
 		},
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"stops",
 			false,
 			true,
-			[]Region{{6, 6}},
-			Args{"word_begin": true},
+			[]text.Region{{6, 6}},
+			backend.Args{"word_begin": true},
 		},
 		{
-			[]Region{{6, 6}},
+			[]text.Region{{6, 6}},
 			"stops",
 			false,
 			false,
-			[]Region{{0, 0}},
-			Args{"word_begin": true},
+			[]text.Region{{0, 0}},
+			backend.Args{"word_begin": true},
 		},
 		{
-			[]Region{{34, 34}},
+			[]text.Region{{34, 34}},
 			"lines",
 			false,
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 			nil,
 		},
 		{
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 			"lines",
 			false,
 			false,
-			[]Region{{10, 10}},
+			[]text.Region{{10, 10}},
 			nil,
 		},
 		{
-			[]Region{{100, 100}},
+			[]text.Region{{100, 100}},
 			"lines",
 			false,
 			false,
-			[]Region{{24, 24}},
+			[]text.Region{{24, 24}},
 			nil,
 		},
 		{
-			[]Region{{12, 12}},
+			[]text.Region{{12, 12}},
 			"lines",
 			false,
 			true,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 			nil,
 		},
 		{
-			[]Region{{35, 35}},
+			[]text.Region{{35, 35}},
 			"lines",
 			false,
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"words",
 			true,
 			true,
-			[]Region{{1, 6}},
+			[]text.Region{{1, 6}},
 			nil,
 		},
 		{
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
 			"words",
 			false,
 			true,
-			[]Region{{6, 6}},
+			[]text.Region{{6, 6}},
 			nil,
 		},
 		{
-			[]Region{{6, 6}, {13, 15}},
+			[]text.Region{{6, 6}, {13, 15}},
 			"words",
 			false,
 			true,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 			nil,
 		},
 		{
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 			"words",
 			false,
 			false,
-			[]Region{{12, 12}},
+			[]text.Region{{12, 12}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"word_ends",
 			true,
 			true,
-			[]Region{{1, 5}},
+			[]text.Region{{1, 5}},
 			nil,
 		},
 		{
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
 			"word_ends",
 			false,
 			true,
-			[]Region{{11, 11}},
+			[]text.Region{{11, 11}},
 			nil,
 		},
 		{
-			[]Region{{11, 11}, {13, 15}},
+			[]text.Region{{11, 11}, {13, 15}},
 			"word_ends",
 			false,
 			true,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 			nil,
 		},
 		{
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 			"word_ends",
 			false,
 			false,
-			[]Region{{12, 12}},
+			[]text.Region{{12, 12}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"subwords",
 			true,
 			true,
-			[]Region{{1, 6}},
+			[]text.Region{{1, 6}},
 			nil,
 		},
 		{
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
 			"subwords",
 			false,
 			true,
-			[]Region{{6, 6}},
+			[]text.Region{{6, 6}},
 			nil,
 		},
 		{
-			[]Region{{6, 6}, {13, 15}},
+			[]text.Region{{6, 6}, {13, 15}},
 			"subwords",
 			false,
 			true,
-			[]Region{{11, 11}, {23, 23}},
+			[]text.Region{{11, 11}, {23, 23}},
 			nil,
 		},
 		{
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 			"subwords",
 			false,
 			false,
-			[]Region{{12, 12}},
+			[]text.Region{{12, 12}},
 			nil,
 		},
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"subword_ends",
 			true,
 			true,
-			[]Region{{1, 5}},
+			[]text.Region{{1, 5}},
 			nil,
 		},
 		{
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
 			"subword_ends",
 			false,
 			true,
-			[]Region{{6, 6}},
+			[]text.Region{{6, 6}},
 			nil,
 		},
 		{
-			[]Region{{6, 6}, {13, 15}},
+			[]text.Region{{6, 6}, {13, 15}},
 			"subword_ends",
 			false,
 			true,
-			[]Region{{11, 11}, {23, 23}},
+			[]text.Region{{11, 11}, {23, 23}},
 			nil,
 		},
 		{
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 			"subword_ends",
 			false,
 			false,
-			[]Region{{12, 12}},
+			[]text.Region{{12, 12}},
 			nil,
 		},
 		// Try moving outside the buffer
 		{
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			"lines",
 			false,
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			nil,
 		},
 		{
-			[]Region{{36, 36}},
+			[]text.Region{{36, 36}},
 			"lines",
 			false,
 			true,
-			[]Region{{36, 36}},
+			[]text.Region{{36, 36}},
 			nil,
 		},
 		{
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			"characters",
 			false,
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			nil,
 		},
 		{
-			[]Region{{36, 36}},
+			[]text.Region{{36, 36}},
 			"characters",
 			false,
 			true,
-			[]Region{{36, 36}},
+			[]text.Region{{36, 36}},
 			nil,
 		},
 	}
-	runMoveTest(tests, t, text)
+	runMoveTest(tests, t, inpuText)
 }
 
 func TestMoveByStops(t *testing.T) {
-	text := "Hello WorLd!\nTest12312{\n\n3Stop (testing) tada}\n Abr_akad[abra"
+	inputText := "Hello WorLd!\nTest12312{\n\n3Stop (testing) tada}\n Abr_akad[abra"
 	tests := []MoveTest{
 		{
-			[]Region{{45, 45}},
+			[]text.Region{{45, 45}},
 			"stops",
 			false,
 			true,
-			[]Region{{56, 56}},
-			Args{"word_end": true},
+			[]text.Region{{56, 56}},
+			backend.Args{"word_end": true},
 		},
 		{
-			[]Region{{45, 45}},
+			[]text.Region{{45, 45}},
 			"stops",
 			false,
 			true,
-			[]Region{{46, 46}},
-			Args{"word_end": true, "separators": ""},
+			[]text.Region{{46, 46}},
+			backend.Args{"word_end": true, "separators": ""},
 		},
 		{
-			[]Region{{8, 8}},
+			[]text.Region{{8, 8}},
 			"stops",
 			false,
 			true,
-			[]Region{{24, 24}},
-			Args{"empty_line": true},
+			[]text.Region{{24, 24}},
+			backend.Args{"empty_line": true},
 		},
 		{
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 			"stops",
 			false,
 			true,
-			[]Region{{4, 4}},
-			Args{"word_begin": true, "separators": "l"},
+			[]text.Region{{4, 4}},
+			backend.Args{"word_begin": true, "separators": "l"},
 		},
 		{
-			[]Region{{58, 58}},
+			[]text.Region{{58, 58}},
 			"stops",
 			false,
 			true,
-			[]Region{{61, 61}},
-			Args{"punct_begin": true},
+			[]text.Region{{61, 61}},
+			backend.Args{"punct_begin": true},
 		},
 		{
-			[]Region{{7, 7}},
+			[]text.Region{{7, 7}},
 			"stops",
 			false,
 			true,
-			[]Region{{12, 12}},
-			Args{"punct_end": true},
+			[]text.Region{{12, 12}},
+			backend.Args{"punct_end": true},
 		},
 	}
-	runMoveTest(tests, t, text)
+	runMoveTest(tests, t, inputText)
 }
 
 func TestMoveWhenWeHaveTabs(t *testing.T) {
-	text := "\ttype qmlfrontend struct {\n\t\tstatus_message string"
+	inputText := "\ttype qmlfrontend struct {\n\t\tstatus_message string"
 	tests := []MoveTest{
 		{
-			[]Region{{35, 35}},
+			[]text.Region{{35, 35}},
 			"lines",
 			false,
 			false,
-			[]Region{{11, 11}},
+			[]text.Region{{11, 11}},
 			nil,
 		},
 		{
-			[]Region{{11, 11}},
+			[]text.Region{{11, 11}},
 			"lines",
 			false,
 			true,
-			[]Region{{35, 35}},
+			[]text.Region{{35, 35}},
 			nil,
 		},
 	}
-	runMoveTest(tests, t, text)
+	runMoveTest(tests, t, inputText)
 }
 
 type scfe struct {
-	show          Region
+	show          text.Region
 	defaultAction bool
 	files         []string
 }
@@ -435,12 +435,12 @@ func (f *scfe) SetDefaultAction(action bool) {
 func (f *scfe) OkCancelDialog(msg string, button string) bool {
 	return f.defaultAction
 }
-func (f *scfe) VisibleRegion(v *View) Region {
+func (f *scfe) VisibleRegion(v *backend.View) text.Region {
 	s := v.Line(v.TextPoint(3*3, 1))
 	e := v.Line(v.TextPoint(6*3, 1))
-	return Region{s.Begin(), e.End()}
+	return text.Region{s.Begin(), e.End()}
 }
-func (f *scfe) Show(v *View, r Region) {
+func (f *scfe) Show(v *backend.View, r text.Region) {
 	f.show = r
 }
 func (f *scfe) Prompt(title, dir string, flags int) []string {
@@ -449,7 +449,7 @@ func (f *scfe) Prompt(title, dir string, flags int) []string {
 
 func TestScrollLines(t *testing.T) {
 	var fe scfe
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetFrontend(&fe)
 	ch := ed.CommandHandler()
 	w := ed.NewWindow()
@@ -465,18 +465,18 @@ func TestScrollLines(t *testing.T) {
 		v.Insert(e, 0, "Hello World!\nTest123123\nAbrakadabra\n")
 	}
 	v.EndEdit(e)
-	ch.RunTextCommand(v, "scroll_lines", Args{"amount": 0})
+	ch.RunTextCommand(v, "scroll_lines", backend.Args{"amount": 0})
 
 	if c := v.Line(v.TextPoint(3*3, 1)); fe.show.Begin() != c.Begin() {
 		t.Errorf("Expected %v, but got %v", c, fe.show)
 	}
 
-	ch.RunTextCommand(v, "scroll_lines", Args{"amount": 1})
+	ch.RunTextCommand(v, "scroll_lines", backend.Args{"amount": 1})
 	if c := v.Line(v.TextPoint(3*3-1, 1)); fe.show.Begin() != c.Begin() {
 		t.Errorf("Expected %v, but got %v", c, fe.show)
 	}
 	t.Log(fe.VisibleRegion(v), v.Line(v.TextPoint(6*3+1, 1)))
-	ch.RunTextCommand(v, "scroll_lines", Args{"amount": -1})
+	ch.RunTextCommand(v, "scroll_lines", backend.Args{"amount": -1})
 	if c := v.Line(v.TextPoint(6*3+1, 1)); fe.show.Begin() != c.Begin() {
 		t.Errorf("Expected %v, but got %v", c, fe.show)
 	}

--- a/moveto_test.go
+++ b/moveto_test.go
@@ -8,19 +8,19 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type MoveToTest struct {
-	in     []Region
+	in     []text.Region
 	to     string
 	extend bool
-	exp    []Region
+	exp    []text.Region
 }
 
 func runMoveToTest(tests []MoveToTest, t *testing.T, text string) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -40,7 +40,7 @@ func runMoveToTest(tests []MoveToTest, t *testing.T, text string) {
 		for _, r := range test.in {
 			v.Sel().Add(r)
 		}
-		args := Args{"to": test.to, "extend": test.extend}
+		args := backend.Args{"to": test.to, "extend": test.extend}
 		ed.CommandHandler().RunTextCommand(v, "move_to", args)
 		if sr := v.Sel().Regions(); !reflect.DeepEqual(sr, test.exp) {
 			t.Errorf("Test %d failed. Expected %v, but got %v: %+v", i, test.exp, sr, test)
@@ -55,36 +55,36 @@ func TestMoveTo(t *testing.T) {
 	       - If extend, the selection will be extended in the direction of movement
 	*/
 
-	singleCursor := []Region{{16, 16}}
+	singleCursor := []text.Region{{16, 16}}
 
-	sameLineCursors := []Region{{16, 16}, {17, 17}}
-	sameLineCursorsReversed := []Region{{17, 17}, {16, 16}}
+	sameLineCursors := []text.Region{{16, 16}, {17, 17}}
+	sameLineCursorsReversed := []text.Region{{17, 17}, {16, 16}}
 
-	diffLineCursors := []Region{{3, 3}, {17, 17}}
-	diffLineCursorsReversed := []Region{{17, 17}, {3, 3}}
+	diffLineCursors := []text.Region{{3, 3}, {17, 17}}
+	diffLineCursorsReversed := []text.Region{{17, 17}, {3, 3}}
 
-	singleForwardSelection := []Region{{15, 18}}
-	singleBackwardSelection := []Region{{18, 15}}
+	singleForwardSelection := []text.Region{{15, 18}}
+	singleBackwardSelection := []text.Region{{18, 15}}
 
-	sameLineForwardSelections := []Region{{15, 18}, {20, 21}}
-	sameLineForwardSelectionsReversed := []Region{{20, 21}, {15, 18}}
-	sameLineBackwardSelections := []Region{{18, 15}, {21, 20}}
-	sameLineBackwardSelectionsReversed := []Region{{21, 20}, {18, 15}}
-	sameLineForwardThenBackwardSelections := []Region{{15, 18}, {21, 20}}
-	sameLineForwardThenBackwardSelectionsReversed := []Region{{21, 20}, {15, 18}}
-	sameLineBackwardThenForwardSelections := []Region{{18, 15}, {20, 21}}
-	sameLineBackwardThenForwardSelectionsReversed := []Region{{20, 21}, {18, 15}}
+	sameLineForwardSelections := []text.Region{{15, 18}, {20, 21}}
+	sameLineForwardSelectionsReversed := []text.Region{{20, 21}, {15, 18}}
+	sameLineBackwardSelections := []text.Region{{18, 15}, {21, 20}}
+	sameLineBackwardSelectionsReversed := []text.Region{{21, 20}, {18, 15}}
+	sameLineForwardThenBackwardSelections := []text.Region{{15, 18}, {21, 20}}
+	sameLineForwardThenBackwardSelectionsReversed := []text.Region{{21, 20}, {15, 18}}
+	sameLineBackwardThenForwardSelections := []text.Region{{18, 15}, {20, 21}}
+	sameLineBackwardThenForwardSelectionsReversed := []text.Region{{20, 21}, {18, 15}}
 
-	diffLineForwardSelections := []Region{{4, 6}, {20, 21}}
-	diffLineForwardSelectionsReversed := []Region{{20, 21}, {4, 6}}
-	diffLineBackwardSelections := []Region{{6, 4}, {21, 20}}
-	diffLineBackwardSelectionsReversed := []Region{{21, 20}, {6, 4}}
-	diffLineForwardThenBackwardSelections := []Region{{4, 6}, {21, 20}}
-	diffLineForwardThenBackwardSelectionsReversed := []Region{{21, 20}, {4, 6}}
-	diffLineBackwardThenForwardSelections := []Region{{6, 4}, {20, 21}}
-	diffLineBackwardThenForwardSelectionsReversed := []Region{{20, 21}, {6, 4}}
+	diffLineForwardSelections := []text.Region{{4, 6}, {20, 21}}
+	diffLineForwardSelectionsReversed := []text.Region{{20, 21}, {4, 6}}
+	diffLineBackwardSelections := []text.Region{{6, 4}, {21, 20}}
+	diffLineBackwardSelectionsReversed := []text.Region{{21, 20}, {6, 4}}
+	diffLineForwardThenBackwardSelections := []text.Region{{4, 6}, {21, 20}}
+	diffLineForwardThenBackwardSelectionsReversed := []text.Region{{21, 20}, {4, 6}}
+	diffLineBackwardThenForwardSelections := []text.Region{{6, 4}, {20, 21}}
+	diffLineBackwardThenForwardSelectionsReversed := []text.Region{{20, 21}, {6, 4}}
 
-	text := "Hello World!\nTest123123\nAbrakadabra\n"
+	inputText := "Hello World!\nTest123123\nAbrakadabra\n"
 	vbufflen := 36
 
 	tests := []MoveToTest{
@@ -93,139 +93,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineCursors,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineCursorsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineCursors,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineCursorsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			singleForwardSelection,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			singleBackwardSelection,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineForwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineBackwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineForwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineBackwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"bof",
 			false,
-			[]Region{{0, 0}},
+			[]text.Region{{0, 0}},
 		},
 
 		// BOF extend
@@ -233,139 +233,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"bof",
 			true,
-			[]Region{{16, 0}},
+			[]text.Region{{16, 0}},
 		},
 		{
 			sameLineCursors,
 			"bof",
 			true,
-			[]Region{{17, 0}},
+			[]text.Region{{17, 0}},
 		},
 		{
 			sameLineCursorsReversed,
 			"bof",
 			true,
-			[]Region{{17, 0}},
+			[]text.Region{{17, 0}},
 		},
 		{
 			diffLineCursors,
 			"bof",
 			true,
-			[]Region{{17, 0}},
+			[]text.Region{{17, 0}},
 		},
 		{
 			diffLineCursorsReversed,
 			"bof",
 			true,
-			[]Region{{17, 0}},
+			[]text.Region{{17, 0}},
 		},
 		{
 			singleForwardSelection,
 			"bof",
 			true,
-			[]Region{{15, 0}},
+			[]text.Region{{15, 0}},
 		},
 		{
 			singleBackwardSelection,
 			"bof",
 			true,
-			[]Region{{18, 0}},
+			[]text.Region{{18, 0}},
 		},
 		{
 			sameLineForwardSelections,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			sameLineBackwardSelections,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			diffLineForwardSelections,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			diffLineBackwardSelections,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{21, 0}},
+			[]text.Region{{21, 0}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"bof",
 			true,
-			[]Region{{20, 0}},
+			[]text.Region{{20, 0}},
 		},
 
 		// EOF move
@@ -373,139 +373,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineCursors,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineCursorsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineCursors,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineCursorsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			singleForwardSelection,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			singleBackwardSelection,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineForwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineBackwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineForwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineBackwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"eof",
 			false,
-			[]Region{{vbufflen, vbufflen}},
+			[]text.Region{{vbufflen, vbufflen}},
 		},
 
 		// EOF extend
@@ -513,139 +513,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"eof",
 			true,
-			[]Region{{16, vbufflen}},
+			[]text.Region{{16, vbufflen}},
 		},
 		{
 			sameLineCursors,
 			"eof",
 			true,
-			[]Region{{16, vbufflen}},
+			[]text.Region{{16, vbufflen}},
 		},
 		{
 			sameLineCursorsReversed,
 			"eof",
 			true,
-			[]Region{{16, vbufflen}},
+			[]text.Region{{16, vbufflen}},
 		},
 		{
 			diffLineCursors,
 			"eof",
 			true,
-			[]Region{{3, vbufflen}},
+			[]text.Region{{3, vbufflen}},
 		},
 		{
 			diffLineCursorsReversed,
 			"eof",
 			true,
-			[]Region{{3, vbufflen}},
+			[]text.Region{{3, vbufflen}},
 		},
 		{
 			singleForwardSelection,
 			"eof",
 			true,
-			[]Region{{15, vbufflen}},
+			[]text.Region{{15, vbufflen}},
 		},
 		{
 			singleBackwardSelection,
 			"eof",
 			true,
-			[]Region{{18, vbufflen}},
+			[]text.Region{{18, vbufflen}},
 		},
 		{
 			sameLineForwardSelections,
 			"eof",
 			true,
-			[]Region{{15, vbufflen}},
+			[]text.Region{{15, vbufflen}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{15, vbufflen}},
+			[]text.Region{{15, vbufflen}},
 		},
 		{
 			sameLineBackwardSelections,
 			"eof",
 			true,
-			[]Region{{18, vbufflen}},
+			[]text.Region{{18, vbufflen}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{18, vbufflen}},
+			[]text.Region{{18, vbufflen}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"eof",
 			true,
-			[]Region{{15, vbufflen}},
+			[]text.Region{{15, vbufflen}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{15, vbufflen}},
+			[]text.Region{{15, vbufflen}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"eof",
 			true,
-			[]Region{{18, vbufflen}},
+			[]text.Region{{18, vbufflen}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{18, vbufflen}},
+			[]text.Region{{18, vbufflen}},
 		},
 		{
 			diffLineForwardSelections,
 			"eof",
 			true,
-			[]Region{{4, vbufflen}},
+			[]text.Region{{4, vbufflen}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{4, vbufflen}},
+			[]text.Region{{4, vbufflen}},
 		},
 		{
 			diffLineBackwardSelections,
 			"eof",
 			true,
-			[]Region{{6, vbufflen}},
+			[]text.Region{{6, vbufflen}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{6, vbufflen}},
+			[]text.Region{{6, vbufflen}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"eof",
 			true,
-			[]Region{{4, vbufflen}},
+			[]text.Region{{4, vbufflen}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{4, vbufflen}},
+			[]text.Region{{4, vbufflen}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"eof",
 			true,
-			[]Region{{6, vbufflen}},
+			[]text.Region{{6, vbufflen}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"eof",
 			true,
-			[]Region{{6, vbufflen}},
+			[]text.Region{{6, vbufflen}},
 		},
 
 		// BOL move
@@ -653,139 +653,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineCursors,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineCursorsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			diffLineCursors,
 			"bol",
 			false,
-			[]Region{{0, 0}, {13, 13}},
+			[]text.Region{{0, 0}, {13, 13}},
 		},
 		{
 			diffLineCursorsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}, {0, 0}},
+			[]text.Region{{13, 13}, {0, 0}},
 		},
 		{
 			singleForwardSelection,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			singleBackwardSelection,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineForwardSelections,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineBackwardSelections,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
 			diffLineForwardSelections,
 			"bol",
 			false,
-			[]Region{{0, 0}, {13, 13}},
+			[]text.Region{{0, 0}, {13, 13}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}, {0, 0}},
+			[]text.Region{{13, 13}, {0, 0}},
 		},
 		{
 			diffLineBackwardSelections,
 			"bol",
 			false,
-			[]Region{{0, 0}, {13, 13}},
+			[]text.Region{{0, 0}, {13, 13}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}, {0, 0}},
+			[]text.Region{{13, 13}, {0, 0}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"bol",
 			false,
-			[]Region{{0, 0}, {13, 13}},
+			[]text.Region{{0, 0}, {13, 13}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}, {0, 0}},
+			[]text.Region{{13, 13}, {0, 0}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"bol",
 			false,
-			[]Region{{0, 0}, {13, 13}},
+			[]text.Region{{0, 0}, {13, 13}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"bol",
 			false,
-			[]Region{{13, 13}, {0, 0}},
+			[]text.Region{{13, 13}, {0, 0}},
 		},
 
 		// BOL extend
@@ -793,139 +793,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"bol",
 			true,
-			[]Region{{16, 13}},
+			[]text.Region{{16, 13}},
 		},
 		{
 			sameLineCursors,
 			"bol",
 			true,
-			[]Region{{17, 13}},
+			[]text.Region{{17, 13}},
 		},
 		{
 			sameLineCursorsReversed,
 			"bol",
 			true,
-			[]Region{{17, 13}},
+			[]text.Region{{17, 13}},
 		},
 		{
 			diffLineCursors,
 			"bol",
 			true,
-			[]Region{{3, 0}, {17, 13}},
+			[]text.Region{{3, 0}, {17, 13}},
 		},
 		{
 			diffLineCursorsReversed,
 			"bol",
 			true,
-			[]Region{{17, 13}, {3, 0}},
+			[]text.Region{{17, 13}, {3, 0}},
 		},
 		{
 			singleForwardSelection,
 			"bol",
 			true,
-			[]Region{{15, 13}},
+			[]text.Region{{15, 13}},
 		},
 		{
 			singleBackwardSelection,
 			"bol",
 			true,
-			[]Region{{18, 13}},
+			[]text.Region{{18, 13}},
 		},
 		{
 			sameLineForwardSelections,
 			"bol",
 			true,
-			[]Region{{20, 13}},
+			[]text.Region{{20, 13}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{20, 13}},
+			[]text.Region{{20, 13}},
 		},
 		{
 			sameLineBackwardSelections,
 			"bol",
 			true,
-			[]Region{{21, 13}},
+			[]text.Region{{21, 13}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{21, 13}},
+			[]text.Region{{21, 13}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"bol",
 			true,
-			[]Region{{21, 13}},
+			[]text.Region{{21, 13}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{21, 13}},
+			[]text.Region{{21, 13}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"bol",
 			true,
-			[]Region{{20, 13}},
+			[]text.Region{{20, 13}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{20, 13}},
+			[]text.Region{{20, 13}},
 		},
 		{
 			diffLineForwardSelections,
 			"bol",
 			true,
-			[]Region{{4, 0}, {20, 13}},
+			[]text.Region{{4, 0}, {20, 13}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{20, 13}, {4, 0}},
+			[]text.Region{{20, 13}, {4, 0}},
 		},
 		{
 			diffLineBackwardSelections,
 			"bol",
 			true,
-			[]Region{{6, 0}, {21, 13}},
+			[]text.Region{{6, 0}, {21, 13}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{21, 13}, {6, 0}},
+			[]text.Region{{21, 13}, {6, 0}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"bol",
 			true,
-			[]Region{{4, 0}, {21, 13}},
+			[]text.Region{{4, 0}, {21, 13}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{21, 13}, {4, 0}},
+			[]text.Region{{21, 13}, {4, 0}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"bol",
 			true,
-			[]Region{{6, 0}, {20, 13}},
+			[]text.Region{{6, 0}, {20, 13}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"bol",
 			true,
-			[]Region{{20, 13}, {6, 0}},
+			[]text.Region{{20, 13}, {6, 0}},
 		},
 
 		// EOL move
@@ -933,139 +933,139 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineCursors,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineCursorsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			diffLineCursors,
 			"eol",
 			false,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 		},
 		{
 			diffLineCursorsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}, {12, 12}},
+			[]text.Region{{23, 23}, {12, 12}},
 		},
 		{
 			singleForwardSelection,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			singleBackwardSelection,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineForwardSelections,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineBackwardSelections,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}},
+			[]text.Region{{23, 23}},
 		},
 		{
 			diffLineForwardSelections,
 			"eol",
 			false,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}, {12, 12}},
+			[]text.Region{{23, 23}, {12, 12}},
 		},
 		{
 			diffLineBackwardSelections,
 			"eol",
 			false,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}, {12, 12}},
+			[]text.Region{{23, 23}, {12, 12}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"eol",
 			false,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}, {12, 12}},
+			[]text.Region{{23, 23}, {12, 12}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"eol",
 			false,
-			[]Region{{12, 12}, {23, 23}},
+			[]text.Region{{12, 12}, {23, 23}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"eol",
 			false,
-			[]Region{{23, 23}, {12, 12}},
+			[]text.Region{{23, 23}, {12, 12}},
 		},
 
 		// EOL extend
@@ -1073,240 +1073,240 @@ func TestMoveTo(t *testing.T) {
 			singleCursor,
 			"eol",
 			true,
-			[]Region{{16, 23}},
+			[]text.Region{{16, 23}},
 		},
 		{
 			sameLineCursors,
 			"eol",
 			true,
-			[]Region{{16, 23}},
+			[]text.Region{{16, 23}},
 		},
 		{
 			sameLineCursorsReversed,
 			"eol",
 			true,
-			[]Region{{16, 23}},
+			[]text.Region{{16, 23}},
 		},
 		{
 			diffLineCursors,
 			"eol",
 			true,
-			[]Region{{3, 12}, {17, 23}},
+			[]text.Region{{3, 12}, {17, 23}},
 		},
 		{
 			diffLineCursorsReversed,
 			"eol",
 			true,
-			[]Region{{17, 23}, {3, 12}},
+			[]text.Region{{17, 23}, {3, 12}},
 		},
 		{
 			singleForwardSelection,
 			"eol",
 			true,
-			[]Region{{15, 23}},
+			[]text.Region{{15, 23}},
 		},
 		{
 			singleBackwardSelection,
 			"eol",
 			true,
-			[]Region{{18, 23}},
+			[]text.Region{{18, 23}},
 		},
 		{
 			sameLineForwardSelections,
 			"eol",
 			true,
-			[]Region{{15, 23}},
+			[]text.Region{{15, 23}},
 		},
 		{
 			sameLineForwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{15, 23}},
+			[]text.Region{{15, 23}},
 		},
 		{
 			sameLineBackwardSelections,
 			"eol",
 			true,
-			[]Region{{18, 23}},
+			[]text.Region{{18, 23}},
 		},
 		{
 			sameLineBackwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{18, 23}},
+			[]text.Region{{18, 23}},
 		},
 		{
 			sameLineForwardThenBackwardSelections,
 			"eol",
 			true,
-			[]Region{{15, 23}},
+			[]text.Region{{15, 23}},
 		},
 		{
 			sameLineForwardThenBackwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{15, 23}},
+			[]text.Region{{15, 23}},
 		},
 		{
 			sameLineBackwardThenForwardSelections,
 			"eol",
 			true,
-			[]Region{{18, 23}},
+			[]text.Region{{18, 23}},
 		},
 		{
 			sameLineBackwardThenForwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{18, 23}},
+			[]text.Region{{18, 23}},
 		},
 		{
 			diffLineForwardSelections,
 			"eol",
 			true,
-			[]Region{{4, 12}, {20, 23}},
+			[]text.Region{{4, 12}, {20, 23}},
 		},
 		{
 			diffLineForwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{20, 23}, {4, 12}},
+			[]text.Region{{20, 23}, {4, 12}},
 		},
 		{
 			diffLineBackwardSelections,
 			"eol",
 			true,
-			[]Region{{6, 12}, {21, 23}},
+			[]text.Region{{6, 12}, {21, 23}},
 		},
 		{
 			diffLineBackwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{21, 23}, {6, 12}},
+			[]text.Region{{21, 23}, {6, 12}},
 		},
 		{
 			diffLineForwardThenBackwardSelections,
 			"eol",
 			true,
-			[]Region{{4, 12}, {21, 23}},
+			[]text.Region{{4, 12}, {21, 23}},
 		},
 		{
 			diffLineForwardThenBackwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{21, 23}, {4, 12}},
+			[]text.Region{{21, 23}, {4, 12}},
 		},
 		{
 			diffLineBackwardThenForwardSelections,
 			"eol",
 			true,
-			[]Region{{6, 12}, {20, 23}},
+			[]text.Region{{6, 12}, {20, 23}},
 		},
 		{
 			diffLineBackwardThenForwardSelectionsReversed,
 			"eol",
 			true,
-			[]Region{{20, 23}, {6, 12}},
+			[]text.Region{{20, 23}, {6, 12}},
 		},
 	}
 
-	runMoveToTest(tests, t, text)
+	runMoveToTest(tests, t, inputText)
 
 	tests = []MoveToTest{
 		// Brackets move
 		{
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"brackets",
 			false,
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 		},
 		{
-			[]Region{{7, 7}},
+			[]text.Region{{7, 7}},
 			"brackets",
 			false,
-			[]Region{{31, 31}},
+			[]text.Region{{31, 31}},
 		},
 		{
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
 			"brackets",
 			false,
-			[]Region{{32, 32}},
+			[]text.Region{{32, 32}},
 		},
 		{
-			[]Region{{9, 9}, {14, 14}},
+			[]text.Region{{9, 9}, {14, 14}},
 			"brackets",
 			false,
-			[]Region{{31, 31}, {16, 16}},
+			[]text.Region{{31, 31}, {16, 16}},
 		},
 		{
-			[]Region{{16, 16}},
+			[]text.Region{{16, 16}},
 			"brackets",
 			false,
-			[]Region{{13, 13}},
+			[]text.Region{{13, 13}},
 		},
 		{
-			[]Region{{32, 32}},
+			[]text.Region{{32, 32}},
 			"brackets",
 			false,
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
 		},
 		{
-			[]Region{{32, 12}},
+			[]text.Region{{32, 12}},
 			"brackets",
 			false,
-			[]Region{{17, 17}},
+			[]text.Region{{17, 17}},
 		},
 		{
-			[]Region{{35, 35}},
+			[]text.Region{{35, 35}},
 			"brackets",
 			false,
-			// Sublime text 3 result is []Region{{35, 35}}
+			// Sublime text 3 result is []text.Region{{35, 35}}
 			// but i think this is a bug
-			[]Region{{38, 38}},
+			[]text.Region{{38, 38}},
 		},
 		{
-			[]Region{{8, 9}, {10, 10}},
+			[]text.Region{{8, 9}, {10, 10}},
 			"brackets",
 			false,
-			[]Region{{31, 31}},
+			[]text.Region{{31, 31}},
 		},
 		{
-			[]Region{{33, 33}},
+			[]text.Region{{33, 33}},
 			"brackets",
 			false,
-			// Sublime text 3 result is []Region{{33, 33}}
+			// Sublime text 3 result is []text.Region{{33, 33}}
 			// but i think this is a bug
-			[]Region{{39, 39}},
+			[]text.Region{{39, 39}},
 		},
 		{
-			[]Region{{36, 36}},
+			[]text.Region{{36, 36}},
 			"brackets",
 			false,
-			[]Region{{36, 36}},
+			[]text.Region{{36, 36}},
 		},
 		{
-			[]Region{{38, 38}},
+			[]text.Region{{38, 38}},
 			"brackets",
 			false,
-			[]Region{{34, 34}},
+			[]text.Region{{34, 34}},
 		},
 		// Breackets extend
 		{
-			[]Region{{8, 9}, {10, 10}},
+			[]text.Region{{8, 9}, {10, 10}},
 			"brackets",
 			true,
-			[]Region{{8, 31}},
+			[]text.Region{{8, 31}},
 		},
 		{
-			[]Region{{17, 17}},
+			[]text.Region{{17, 17}},
 			"brackets",
 			true,
-			[]Region{{17, 24}},
+			[]text.Region{{17, 24}},
 		},
 		{
-			[]Region{{1, 1}, {14, 14}},
+			[]text.Region{{1, 1}, {14, 14}},
 			"brackets",
 			true,
-			[]Region{{1, 1}, {14, 16}},
+			[]text.Region{{1, 1}, {14, 16}},
 		},
 	}
 

--- a/nop.go
+++ b/nop.go
@@ -26,7 +26,8 @@ func (c *NopApplication) Run() error {
 	return nil
 }
 
-//IsChecked is
+// IsChecked will represent if the command will
+// contain a checkbox in the UI
 func (c *NopApplication) IsChecked() bool {
 	return false
 }

--- a/nop.go
+++ b/nop.go
@@ -21,23 +21,23 @@ type (
 	}
 )
 
-// Run will execute the NopApplication command
+// Run executes the NopApplication command.
 func (c *NopApplication) Run() error {
 	return nil
 }
 
-// IsChecked will represent if the command will
-// contain a checkbox in the UI
+// IsChecked will represent if the command
+// contains a checkbox in the frontend
 func (c *NopApplication) IsChecked() bool {
 	return false
 }
 
-// Run will execute the NopWindow command
+// Run executes the NopWindow command.
 func (c *NopWindow) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run will execute the NopText command
+// Run executes the NopText command.
 func (c *NopText) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }

--- a/nop.go
+++ b/nop.go
@@ -7,15 +7,15 @@ package commands
 import "github.com/limetext/backend"
 
 type (
-	// NopApplication is
+	// NopApplication performs NOP.
 	NopApplication struct {
 		backend.BypassUndoCommand
 	}
-	// NopWindow is
+	// NopWindow performs NOP.
 	NopWindow struct {
 		backend.BypassUndoCommand
 	}
-	// NopText is
+	// NopText performs NOP.
 	NopText struct {
 		backend.BypassUndoCommand
 	}
@@ -26,7 +26,7 @@ func (c *NopApplication) Run() error {
 	return nil
 }
 
-// IsChecked will represent if the command
+// IsChecked represents if the command
 // contains a checkbox in the frontend
 func (c *NopApplication) IsChecked() bool {
 	return false

--- a/nop.go
+++ b/nop.go
@@ -4,35 +4,40 @@
 
 package commands
 
-import . "github.com/limetext/backend"
+import "github.com/limetext/backend"
 
 type (
+	//NopApplication is
 	NopApplication struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
-
+	//NopWindow is
 	NopWindow struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
-
+	//NopText is
 	NopText struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 	}
 )
 
+//Run will execute the NopApplication command
 func (c *NopApplication) Run() error {
 	return nil
 }
 
+//IsChecked is
 func (c *NopApplication) IsChecked() bool {
 	return false
 }
 
-func (c *NopWindow) Run(w *Window) error {
+//Run will execute the NopWindow command
+func (c *NopWindow) Run(w *backend.Window) error {
 	return nil
 }
 
-func (c *NopText) Run(v *View, e *Edit) error {
+//Run will execute the NopText command
+func (c *NopText) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 

--- a/nop.go
+++ b/nop.go
@@ -7,21 +7,21 @@ package commands
 import "github.com/limetext/backend"
 
 type (
-	//NopApplication is
+	// NopApplication is
 	NopApplication struct {
 		backend.BypassUndoCommand
 	}
-	//NopWindow is
+	// NopWindow is
 	NopWindow struct {
 		backend.BypassUndoCommand
 	}
-	//NopText is
+	// NopText is
 	NopText struct {
 		backend.BypassUndoCommand
 	}
 )
 
-//Run will execute the NopApplication command
+// Run will execute the NopApplication command
 func (c *NopApplication) Run() error {
 	return nil
 }
@@ -31,12 +31,12 @@ func (c *NopApplication) IsChecked() bool {
 	return false
 }
 
-//Run will execute the NopWindow command
+// Run will execute the NopWindow command
 func (c *NopWindow) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run will execute the NopText command
+// Run will execute the NopText command
 func (c *NopText) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }

--- a/nop_test.go
+++ b/nop_test.go
@@ -7,7 +7,7 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 func TestRunApplication(t *testing.T) {
@@ -22,7 +22,7 @@ func TestRunApplication(t *testing.T) {
 func TestRunNopWindow(t *testing.T) {
 	nopWindow := NopWindow{}
 
-	if nopWindow.Run(&Window{}) != nil {
+	if nopWindow.Run(&backend.Window{}) != nil {
 		t.Error("No op window command running returns not nil")
 	}
 }
@@ -30,7 +30,7 @@ func TestRunNopWindow(t *testing.T) {
 func TestRunNopText(t *testing.T) {
 	nopText := NopText{}
 
-	if nopText.Run(&View{}, &Edit{}) != nil {
+	if nopText.Run(&backend.View{}, &backend.Edit{}) != nil {
 		t.Error("No op text command running returns not nil")
 	}
 }

--- a/project.go
+++ b/project.go
@@ -7,35 +7,48 @@ package commands
 import (
 	"fmt"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
+
+	//SaveProjectAs command will enable us to save the
+	//as a text file, which can then be imported
+	//into lime using PromptOpenProject command.
 	SaveProjectAs struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//PromptOpenProject command enables us to open the
+	//project file saved using the SaveProjectAs command
 	PromptOpenProject struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//CloseProject command enables us to close an existing
+	//open project
 	CloseProject struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//PromptAddFolder will add a folder to the existing
+	//opened project
 	PromptAddFolder struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//CloseFolderList removes the folder list from the
+	//opened project
 	CloseFolderList struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *SaveProjectAs) Run(w *Window) error {
+//Run will execute the SaveProjectAs command
+func (c *SaveProjectAs) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
-	fe := GetEditor().Frontend()
-	files := fe.Prompt("Save file", dir, PROMPT_SAVE_AS)
+	fe := backend.GetEditor().Frontend()
+	files := fe.Prompt("Save file", dir, backend.PROMPT_SAVE_AS)
 	if len(files) == 0 {
 		return nil
 	}
@@ -48,9 +61,10 @@ func (c *SaveProjectAs) Run(w *Window) error {
 	return nil
 }
 
-func (c *PromptOpenProject) Run(w *Window) error {
+//Run will execute the PromptOpenProject command
+func (c *PromptOpenProject) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
-	fe := GetEditor().Frontend()
+	fe := backend.GetEditor().Frontend()
 	files := fe.Prompt("Open file", dir, 0)
 	if len(files) == 0 {
 		return nil
@@ -63,22 +77,25 @@ func (c *PromptOpenProject) Run(w *Window) error {
 	return nil
 }
 
-func (c *CloseProject) Run(w *Window) error {
+//Run will execute the CloseProject command
+func (c *CloseProject) Run(w *backend.Window) error {
 	w.Project().Close()
 	return nil
 }
 
-func (c *PromptAddFolder) Run(w *Window) error {
+//Run will execute the PromptAddFolder command
+func (c *PromptAddFolder) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
-	fe := GetEditor().Frontend()
-	folders := fe.Prompt("Open file", dir, PROMPT_ONLY_FOLDER|PROMPT_SELECT_MULTIPLE)
+	fe := backend.GetEditor().Frontend()
+	folders := fe.Prompt("Open file", dir, backend.PROMPT_ONLY_FOLDER|backend.PROMPT_SELECT_MULTIPLE)
 	for _, folder := range folders {
 		w.Project().AddFolder(folder)
 	}
 	return nil
 }
 
-func (c *CloseFolderList) Run(w *Window) error {
+//Run will execute the CloseFolderList command
+func (c *CloseFolderList) Run(w *backend.Window) error {
 	for _, folder := range w.Project().Folders() {
 		w.Project().RemoveFolder(folder)
 	}
@@ -86,7 +103,7 @@ func (c *CloseFolderList) Run(w *Window) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&SaveProjectAs{},
 		&PromptOpenProject{},
 		&CloseProject{},

--- a/project.go
+++ b/project.go
@@ -12,39 +12,39 @@ import (
 
 type (
 
-	//SaveProjectAs command will enable us to save the
-	//as a text file, which can then be imported
-	//into lime using PromptOpenProject command.
+	// SaveProjectAs command will enable us to save the
+	// as a text file, which can then be imported
+	// into lime using PromptOpenProject command.
 	SaveProjectAs struct {
 		backend.DefaultCommand
 	}
 
-	//PromptOpenProject command enables us to open the
-	//project file saved using the SaveProjectAs command
+	// PromptOpenProject command enables us to open the
+	// project file saved using the SaveProjectAs command
 	PromptOpenProject struct {
 		backend.DefaultCommand
 	}
 
-	//CloseProject command enables us to close an existing
-	//open project
+	// CloseProject command enables us to close an existing
+	// open project
 	CloseProject struct {
 		backend.DefaultCommand
 	}
 
-	//PromptAddFolder will add a folder to the existing
-	//opened project
+	// PromptAddFolder will add a folder to the existing
+	// opened project
 	PromptAddFolder struct {
 		backend.DefaultCommand
 	}
 
-	//CloseFolderList removes the folder list from the
-	//opened project
+	// CloseFolderList removes the folder list from the
+	// opened project
 	CloseFolderList struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run will execute the SaveProjectAs command
+// Run will execute the SaveProjectAs command
 func (c *SaveProjectAs) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()
@@ -61,7 +61,7 @@ func (c *SaveProjectAs) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run will execute the PromptOpenProject command
+// Run will execute the PromptOpenProject command
 func (c *PromptOpenProject) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()
@@ -77,13 +77,13 @@ func (c *PromptOpenProject) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run will execute the CloseProject command
+// Run will execute the CloseProject command
 func (c *CloseProject) Run(w *backend.Window) error {
 	w.Project().Close()
 	return nil
 }
 
-//Run will execute the PromptAddFolder command
+// Run will execute the PromptAddFolder command
 func (c *PromptAddFolder) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()
@@ -94,7 +94,7 @@ func (c *PromptAddFolder) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run will execute the CloseFolderList command
+// Run will execute the CloseFolderList command
 func (c *CloseFolderList) Run(w *backend.Window) error {
 	for _, folder := range w.Project().Folders() {
 		w.Project().RemoveFolder(folder)

--- a/project.go
+++ b/project.go
@@ -12,7 +12,7 @@ import (
 
 type (
 
-	// SaveProjectAs command will enable us to save the
+	// SaveProjectAs command enables us to save the project
 	// as a text file, which can then be imported
 	// into lime using PromptOpenProject command.
 	SaveProjectAs struct {
@@ -20,31 +20,31 @@ type (
 	}
 
 	// PromptOpenProject command enables us to open the
-	// project file saved using the SaveProjectAs command
+	// project file saved using the SaveProjectAs command.
 	PromptOpenProject struct {
 		backend.DefaultCommand
 	}
 
 	// CloseProject command enables us to close an existing
-	// open project
+	// open project.
 	CloseProject struct {
 		backend.DefaultCommand
 	}
 
-	// PromptAddFolder will add a folder to the existing
-	// opened project
+	// PromptAddFolder adds a folder to the existing
+	// opened project.
 	PromptAddFolder struct {
 		backend.DefaultCommand
 	}
 
 	// CloseFolderList removes the folder list from the
-	// opened project
+	// opened project.
 	CloseFolderList struct {
 		backend.DefaultCommand
 	}
 )
 
-// Run will execute the SaveProjectAs command
+// Run executes the SaveProjectAs command.
 func (c *SaveProjectAs) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()
@@ -61,7 +61,7 @@ func (c *SaveProjectAs) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run will execute the PromptOpenProject command
+// Run executes the PromptOpenProject command.
 func (c *PromptOpenProject) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()
@@ -77,13 +77,13 @@ func (c *PromptOpenProject) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run will execute the CloseProject command
+// Run executes the CloseProject command.
 func (c *CloseProject) Run(w *backend.Window) error {
 	w.Project().Close()
 	return nil
 }
 
-// Run will execute the PromptAddFolder command
+// Run executes the PromptAddFolder command.
 func (c *PromptAddFolder) Run(w *backend.Window) error {
 	dir := viewDirectory(w.ActiveView())
 	fe := backend.GetEditor().Frontend()
@@ -94,7 +94,7 @@ func (c *PromptAddFolder) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run will execute the CloseFolderList command
+// Run executes the CloseFolderList command.
 func (c *CloseFolderList) Run(w *backend.Window) error {
 	for _, folder := range w.Project().Folders() {
 		w.Project().RemoveFolder(folder)

--- a/project_test.go
+++ b/project_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 func TestSaveProjectAs(t *testing.T) {
@@ -17,7 +17,7 @@ func TestSaveProjectAs(t *testing.T) {
 
 	var fe scfe
 	fe.files = []string{testfile}
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetFrontend(&fe)
 	w := ed.NewWindow()
 	defer w.Close()
@@ -35,7 +35,7 @@ func TestPromptAddFolder(t *testing.T) {
 	var fe scfe
 	fe.files = []string{testfolder}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetFrontend(&fe)
 	w := ed.NewWindow()
 	defer w.Close()
@@ -53,7 +53,7 @@ func TestPromptAddFolder(t *testing.T) {
 }
 
 func TestCloseFolderList(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 	p := w.Project()
@@ -64,6 +64,6 @@ func TestCloseFolderList(t *testing.T) {
 		t.Errorf("Error running 'close_folder_list' command: %s", err)
 	}
 	if len(p.Folders()) != 0 {
-		t.Error("Expected project folders list be empty, but got %s", p.Folders())
+		t.Errorf("Expected project folders list be empty, but got %s", p.Folders())
 	}
 }

--- a/register_test.go
+++ b/register_test.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type DummyApplicationCommand struct {
-	DefaultCommand
+	backend.DefaultCommand
 }
 
 func (c *DummyApplicationCommand) Run() error {
@@ -24,7 +24,7 @@ func (c *DummyApplicationCommand) IsChecked() bool {
 }
 
 func TestRegisterByName(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 
 	name := "dummy"
 
@@ -42,14 +42,14 @@ func TestRegisterByName(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ac := &DummyApplicationCommand{}
 
-	register([]Command{
+	register([]backend.Command{
 		ac,
 	})
 
-	name := DefaultName(ac)
+	name := backend.DefaultName(ac)
 	err := ed.CommandHandler().RunApplicationCommand(name, nil)
 
 	if err == nil {

--- a/save.go
+++ b/save.go
@@ -12,26 +12,26 @@ import (
 
 type (
 
-	// Save command will save the currently
-	// opened file to the disk
+	// Save command writes the currently
+	// opened file to the disk.
 	Save struct {
 		backend.DefaultCommand
 	}
 
-	// PromptSaveAs command will let us save
-	// the currently opened
-	// file with a different file name
+	// PromptSaveAs command lets us save
+	// the currently active
+	// file with a different name.
 	PromptSaveAs struct {
 		backend.DefaultCommand
 	}
 
-	// SaveAll command will save all the opene files
+	// SaveAll command saves all the opene files to the disk.
 	SaveAll struct {
 		backend.DefaultCommand
 	}
 )
 
-// Run will execute the Save command
+// Run executes the Save command.
 func (c *Save) Run(v *backend.View, e *backend.Edit) error {
 	err := v.Save()
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *Save) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the PromptSaveAs command
+// Run executes the PromptSaveAs command.
 func (c *PromptSaveAs) Run(v *backend.View, e *backend.Edit) error {
 	dir := viewDirectory(v)
 	fe := backend.GetEditor().Frontend()
@@ -58,7 +58,7 @@ func (c *PromptSaveAs) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the SaveAll command
+// Run executes the SaveAll command.
 func (c *SaveAll) Run(w *backend.Window) error {
 	fe := backend.GetEditor().Frontend()
 	for _, v := range w.Views() {

--- a/save.go
+++ b/save.go
@@ -25,7 +25,7 @@ type (
 		backend.DefaultCommand
 	}
 
-	// SaveAll command saves all the opene files to the disk.
+	// SaveAll command saves all the open files to the disk.
 	SaveAll struct {
 		backend.DefaultCommand
 	}

--- a/save.go
+++ b/save.go
@@ -12,26 +12,26 @@ import (
 
 type (
 
-	//Save command will save the currently
-	//opened file to the disk
+	// Save command will save the currently
+	// opened file to the disk
 	Save struct {
 		backend.DefaultCommand
 	}
 
-	//PromptSaveAs command will let us save
-	//the currently opened
-	//file with a different file name
+	// PromptSaveAs command will let us save
+	// the currently opened
+	// file with a different file name
 	PromptSaveAs struct {
 		backend.DefaultCommand
 	}
 
-	//SaveAll command will save all the opene files
+	// SaveAll command will save all the opene files
 	SaveAll struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run will execute the Save command
+// Run will execute the Save command
 func (c *Save) Run(v *backend.View, e *backend.Edit) error {
 	err := v.Save()
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *Save) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the PromptSaveAs command
+// Run will execute the PromptSaveAs command
 func (c *PromptSaveAs) Run(v *backend.View, e *backend.Edit) error {
 	dir := viewDirectory(v)
 	fe := backend.GetEditor().Frontend()
@@ -58,7 +58,7 @@ func (c *PromptSaveAs) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the SaveAll command
+// Run will execute the SaveAll command
 func (c *SaveAll) Run(w *backend.Window) error {
 	fe := backend.GetEditor().Frontend()
 	for _, v := range w.Views() {

--- a/save.go
+++ b/save.go
@@ -7,36 +7,45 @@ package commands
 import (
 	"fmt"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
+
+	//Save command will save the currently
+	//opened file to the disk
 	Save struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//PromptSaveAs command will let us save
+	//the currently opened
+	//file with a different file name
 	PromptSaveAs struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//SaveAll command will save all the opene files
 	SaveAll struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *Save) Run(v *View, e *Edit) error {
+//Run will execute the Save command
+func (c *Save) Run(v *backend.View, e *backend.Edit) error {
 	err := v.Save()
 	if err != nil {
-		GetEditor().Frontend().ErrorMessage(fmt.Sprintf("Failed to save %s:n%s", v.FileName(), err))
+		backend.GetEditor().Frontend().ErrorMessage(fmt.Sprintf("Failed to save %s:n%s", v.FileName(), err))
 		return err
 	}
 	return nil
 }
 
-func (c *PromptSaveAs) Run(v *View, e *Edit) error {
+//Run will execute the PromptSaveAs command
+func (c *PromptSaveAs) Run(v *backend.View, e *backend.Edit) error {
 	dir := viewDirectory(v)
-	fe := GetEditor().Frontend()
-	files := fe.Prompt("Save file", dir, PROMPT_SAVE_AS)
+	fe := backend.GetEditor().Frontend()
+	files := fe.Prompt("Save file", dir, backend.PROMPT_SAVE_AS)
 	if len(files) == 0 {
 		return nil
 	}
@@ -49,8 +58,9 @@ func (c *PromptSaveAs) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SaveAll) Run(w *Window) error {
-	fe := GetEditor().Frontend()
+//Run will execute the SaveAll command
+func (c *SaveAll) Run(w *backend.Window) error {
+	fe := backend.GetEditor().Frontend()
 	for _, v := range w.Views() {
 		if err := v.Save(); err != nil {
 			fe.ErrorMessage(fmt.Sprintf("Failed to save %s:n%s", v.FileName(), err))
@@ -61,7 +71,7 @@ func (c *SaveAll) Run(w *Window) error {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Save{},
 		&PromptSaveAs{},
 		&SaveAll{},

--- a/save_test.go
+++ b/save_test.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
-var testfile string = "testdata/save_test.txt"
+var testfile = "testdata/save_test.txt"
 
 func TestSave(t *testing.T) {
 	hold, err := ioutil.ReadFile(testfile)
@@ -37,7 +37,7 @@ func TestSave(t *testing.T) {
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -77,7 +77,7 @@ func TestSaveAs(t *testing.T) {
 	const name = "testdata/save_as_test.txt"
 	fe.files = []string{name}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetFrontend(&fe)
 	w := ed.NewWindow()
 	defer w.Close()
@@ -106,7 +106,7 @@ func TestSaveAs(t *testing.T) {
 func TestSaveAll(t *testing.T) {
 	var err error
 	holds := make(map[int][]byte)
-	views := make(map[int]*View)
+	views := make(map[int]*backend.View)
 	files := []struct {
 		file   string
 		expect string
@@ -121,7 +121,7 @@ func TestSaveAll(t *testing.T) {
 		},
 	}
 
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetFrontend(&scfe{})
 	fe := ed.Frontend()
 	if dfe, ok := fe.(*scfe); ok {

--- a/select.go
+++ b/select.go
@@ -16,13 +16,13 @@ type (
 		backend.DefaultCommand
 	}
 	// SelectAll command selects the whole buffer of
-	// the current file
+	// the current file.
 	SelectAll struct {
 		backend.DefaultCommand
 	}
 )
 
-// Run will execute the SingleSelection command
+// Run executes the SingleSelection command.
 func (c *SingleSelection) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of SingleSelect:
@@ -35,7 +35,7 @@ func (c *SingleSelection) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the SelectAll command
+// Run executes the SelectAll command.
 func (c *SelectAll) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of SelectAll:

--- a/select.go
+++ b/select.go
@@ -5,23 +5,25 @@
 package commands
 
 import (
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type (
-	// The SingleSelectionCommand merges multiple cursors
+	//SingleSelection command merges multiple cursors
 	// into a single one.
 	SingleSelection struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
-	// The SelectAllCommand selects the whole buffer of the current file
+	// SelectAll command selects the whole buffer of
+	//the current file
 	SelectAll struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *SingleSelection) Run(v *View, e *Edit) error {
+//Run will execute the SingleSelection command
+func (c *SingleSelection) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of SingleSelect:
 			- Remove all selection regions but the first.
@@ -33,20 +35,21 @@ func (c *SingleSelection) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SelectAll) Run(v *View, e *Edit) error {
+//Run will execute the SelectAll command
+func (c *SelectAll) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of SelectAll:
 			- Select a single region of (0, view.buffersize())
 	*/
 
-	r := Region{0, v.Size()}
+	r := text.Region{0, v.Size()}
 	v.Sel().Clear()
 	v.Sel().Add(r)
 	return nil
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&SingleSelection{},
 		&SelectAll{},
 	})

--- a/select.go
+++ b/select.go
@@ -10,19 +10,19 @@ import (
 )
 
 type (
-	//SingleSelection command merges multiple cursors
+	// SingleSelection command merges multiple cursors
 	// into a single one.
 	SingleSelection struct {
 		backend.DefaultCommand
 	}
 	// SelectAll command selects the whole buffer of
-	//the current file
+	// the current file
 	SelectAll struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run will execute the SingleSelection command
+// Run will execute the SingleSelection command
 func (c *SingleSelection) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of SingleSelect:
@@ -35,7 +35,7 @@ func (c *SingleSelection) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the SelectAll command
+// Run will execute the SelectAll command
 func (c *SelectAll) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of SelectAll:

--- a/select_test.go
+++ b/select_test.go
@@ -7,27 +7,27 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/text"
+	"github.com/limetext/text"
 )
 
 func TestSingleSelection(t *testing.T) {
 	tests := []findTest{
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{1, 1}, {2, 2}, {3, 3}, {6, 6}},
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}, {2, 2}, {3, 3}, {6, 6}},
+			[]text.Region{{1, 1}},
 			false,
 		},
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{2, 2}, {3, 3}, {6, 6}},
-			[]Region{{2, 2}},
+			[]text.Region{{2, 2}, {3, 3}, {6, 6}},
+			[]text.Region{{2, 2}},
 			false,
 		},
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{5, 5}},
-			[]Region{{5, 5}},
+			[]text.Region{{5, 5}},
+			[]text.Region{{5, 5}},
 			false,
 		},
 	}
@@ -39,20 +39,20 @@ func TestSelectAll(t *testing.T) {
 	tests := []findTest{
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{1, 1}, {2, 2}, {3, 3}, {6, 6}},
-			[]Region{{0, 36}},
+			[]text.Region{{1, 1}, {2, 2}, {3, 3}, {6, 6}},
+			[]text.Region{{0, 36}},
 			false,
 		},
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{2, 2}, {3, 3}, {6, 6}},
-			[]Region{{0, 36}},
+			[]text.Region{{2, 2}, {3, 3}, {6, 6}},
+			[]text.Region{{0, 36}},
 			false,
 		},
 		{
 			"Hello World!\nTest123123\nAbrakadabra\n",
-			[]Region{{5, 5}},
-			[]Region{{0, 36}},
+			[]text.Region{{5, 5}},
+			[]text.Region{{0, 36}},
 			false,
 		},
 	}

--- a/settings.go
+++ b/settings.go
@@ -58,7 +58,7 @@ type toggleSetting struct {
 	backend.BypassUndoCommand
 }
 
-// Run will execute the ToggleSetting command
+// Run executes the ToggleSetting command
 func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	prev, boolean := v.Settings().Get(setting, false).(bool)
@@ -67,14 +67,14 @@ func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run will execute the SetSetting command
+// Run executes the SetSetting command
 func (c *SetSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	v.Settings().Set(setting, c.Value)
 	return nil
 }
 
-// Run will execute the
+// Run executes the
 func (t *toggleSetting) Run(w *backend.Window) error {
 	res, ok := w.Settings().Get(t.name, false).(bool)
 	w.Settings().Set(t.name, !ok || !res)

--- a/settings.go
+++ b/settings.go
@@ -23,17 +23,17 @@ type (
 
 	// ToggleSideBar Command enables us to toggle the sidebar
 	// when the sidebar is visible, it'll be made invisible
-	// and vice versa
+	// and vice versa.
 	ToggleSideBar struct {
 		toggleSetting
 	}
 
-	//ToggleStatusBar command enables us to toggle the status bar
+	// ToggleStatusBar command enables us to toggle the status bar.
 	ToggleStatusBar struct {
 		toggleSetting
 	}
 
-	//ToggleFullScreen command enables us to toggle full screen
+	// ToggleFullScreen command enables us to toggle full screen.
 	ToggleFullScreen struct {
 		toggleSetting
 	}
@@ -51,14 +51,14 @@ type (
 	}
 )
 
-// helper struct for commands that just toggle a simple setting
+// helper struct for commands that just toggle a simple setting.
 type toggleSetting struct {
-	// the setting name which we are going to toggle
+	// the setting name which we are going to toggle.
 	name string
 	backend.BypassUndoCommand
 }
 
-// Run executes the ToggleSetting command
+// Run executes the ToggleSetting command.
 func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	prev, boolean := v.Settings().Get(setting, false).(bool)
@@ -67,14 +67,13 @@ func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run executes the SetSetting command
+// Run executes the SetSetting command.
 func (c *SetSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	v.Settings().Set(setting, c.Value)
 	return nil
 }
 
-// Run executes the
 func (t *toggleSetting) Run(w *backend.Window) error {
 	res, ok := w.Settings().Get(t.name, false).(bool)
 	w.Settings().Set(t.name, !ok || !res)

--- a/settings.go
+++ b/settings.go
@@ -4,31 +4,36 @@
 
 package commands
 
-import . "github.com/limetext/backend"
+import "github.com/limetext/backend"
 
 type (
-	// The ToggleSettingCommand toggles the value of a setting,
+	// ToggleSetting Command toggles the value of a setting,
 	// making it false when it was true or true when it was false.
 	ToggleSetting struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 		Setting string
 	}
 
-	// The SetSettingCommand set the value of a setting.
+	// SetSetting Command set the value of a setting.
 	SetSetting struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 		Setting string
 		Value   interface{}
 	}
 
+	//ToggleSideBar Command enables us to toggle the sidebar
+	//when the sidebar is visible, it'll be made invisible
+	//and vice versa
 	ToggleSideBar struct {
 		toggleSetting
 	}
 
+	//ToggleStatusBar command enables us to toggle the status bar
 	ToggleStatusBar struct {
 		toggleSetting
 	}
 
+	//ToggleFullScreen command enables us to toggle full screen
 	ToggleFullScreen struct {
 		toggleSetting
 	}
@@ -50,10 +55,11 @@ type (
 type toggleSetting struct {
 	// the setting name which we are going to toggle
 	name string
-	BypassUndoCommand
+	backend.BypassUndoCommand
 }
 
-func (c *ToggleSetting) Run(v *View, e *Edit) error {
+//Run will execute the ToggleSetting command
+func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	prev, boolean := v.Settings().Get(setting, false).(bool)
 	// if the setting was non-boolean, it is set to true, else it is toggled
@@ -61,13 +67,15 @@ func (c *ToggleSetting) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SetSetting) Run(v *View, e *Edit) error {
+//Run will execute the SetSetting command
+func (c *SetSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	v.Settings().Set(setting, c.Value)
 	return nil
 }
 
-func (t *toggleSetting) Run(w *Window) error {
+//Run will execute the
+func (t *toggleSetting) Run(w *backend.Window) error {
 	res, ok := w.Settings().Get(t.name, false).(bool)
 	w.Settings().Set(t.name, !ok || !res)
 	return nil
@@ -78,7 +86,7 @@ func toggle(name string) toggleSetting {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&ToggleSetting{},
 		&SetSetting{},
 		&ToggleSideBar{toggle("show_side_bar")},

--- a/settings.go
+++ b/settings.go
@@ -21,9 +21,9 @@ type (
 		Value   interface{}
 	}
 
-	//ToggleSideBar Command enables us to toggle the sidebar
-	//when the sidebar is visible, it'll be made invisible
-	//and vice versa
+	// ToggleSideBar Command enables us to toggle the sidebar
+	// when the sidebar is visible, it'll be made invisible
+	// and vice versa
 	ToggleSideBar struct {
 		toggleSetting
 	}
@@ -58,7 +58,7 @@ type toggleSetting struct {
 	backend.BypassUndoCommand
 }
 
-//Run will execute the ToggleSetting command
+// Run will execute the ToggleSetting command
 func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	prev, boolean := v.Settings().Get(setting, false).(bool)
@@ -67,14 +67,14 @@ func (c *ToggleSetting) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run will execute the SetSetting command
+// Run will execute the SetSetting command
 func (c *SetSetting) Run(v *backend.View, e *backend.Edit) error {
 	setting := c.Setting
 	v.Settings().Set(setting, c.Value)
 	return nil
 }
 
-//Run will execute the
+// Run will execute the
 func (t *toggleSetting) Run(w *backend.Window) error {
 	res, ok := w.Settings().Get(t.name, false).(bool)
 	w.Settings().Set(t.name, !ok || !res)

--- a/settings_test.go
+++ b/settings_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 func TestToggleSetting(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -26,32 +26,32 @@ func TestToggleSetting(t *testing.T) {
 	v.Settings().Set("favorite_color", "blue")
 
 	// non-existant -> true
-	ed.CommandHandler().RunTextCommand(v, "toggle_setting", Args{"setting": "rabbit"})
+	ed.CommandHandler().RunTextCommand(v, "toggle_setting", backend.Args{"setting": "rabbit"})
 	if val, ok := v.Settings().Get("rabbit").(bool); !ok || !val {
 		t.Errorf("Toggling an non-existant setting should make it true")
 	}
 
 	// non-bool -> true
-	ed.CommandHandler().RunTextCommand(v, "toggle_setting", Args{"setting": "favorite_color"})
+	ed.CommandHandler().RunTextCommand(v, "toggle_setting", backend.Args{"setting": "favorite_color"})
 	if val, ok := v.Settings().Get("favorite_color").(bool); !ok || !val {
 		t.Errorf("Toggling an non-bool setting should make it true")
 	}
 
 	// bool: true -> false
-	ed.CommandHandler().RunTextCommand(v, "toggle_setting", Args{"setting": "duck"})
+	ed.CommandHandler().RunTextCommand(v, "toggle_setting", backend.Args{"setting": "duck"})
 	if val, ok := v.Settings().Get("duck").(bool); !ok || val {
 		t.Errorf("Setting should be toggled from true to false")
 	}
 
 	// bool: false -> true
-	ed.CommandHandler().RunTextCommand(v, "toggle_setting", Args{"setting": "witch"})
+	ed.CommandHandler().RunTextCommand(v, "toggle_setting", backend.Args{"setting": "witch"})
 	if val, ok := v.Settings().Get("witch").(bool); !ok || !val {
 		t.Errorf("Setting should be toggled from false to true")
 	}
 }
 
 func TestSetSetting(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -63,7 +63,7 @@ func TestSetSetting(t *testing.T) {
 	v.Settings().Set("favorite_color", "blue")
 
 	exp := "red"
-	ed.CommandHandler().RunTextCommand(v, "set_setting", Args{"setting": "favorite_color", "value": exp})
+	ed.CommandHandler().RunTextCommand(v, "set_setting", backend.Args{"setting": "favorite_color", "value": exp})
 	val := v.Settings().Get("favorite_color")
 	if s, ok := val.(string); !ok || s != exp {
 		t.Errorf("Expecting setting value to be %#v, was %#v", exp, val)
@@ -79,7 +79,7 @@ func TestToggles(t *testing.T) {
 }
 
 func toggleTest(t *testing.T, name string) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 

--- a/sort.go
+++ b/sort.go
@@ -72,7 +72,7 @@ func (s textSorter) Less(i, j int) bool {
 	return textA < textB
 }
 
-//Run will execute the SortLines command
+// Run will execute the SortLines command
 func (c *SortLines) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	// Used as a set of int
@@ -119,7 +119,7 @@ func (c *SortLines) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-//Run executes the sort slection command
+// Run executes the sort slection command
 func (c *SortSelection) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	regions := make([]text.Region, sel.Len())

--- a/sort.go
+++ b/sort.go
@@ -8,32 +8,32 @@ import (
 	"sort"
 	"strings"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type (
-	// The SortLinesCommand sorts all lines
+	// SortLines Command sorts all lines
 	// intersecting a selection region
 	SortLines struct {
-		DefaultCommand
+		backend.DefaultCommand
 		CaseSensitive    bool
 		Reverse          bool
 		RemoveDuplicates bool
 	}
 
-	// The SortSelectionCommand sorts contents
+	// SortSelection Command sorts contents
 	// of each selection region with respect to
 	// each other
 	SortSelection struct {
-		DefaultCommand
+		backend.DefaultCommand
 		CaseSensitive    bool
 		Reverse          bool
 		RemoveDuplicates bool
 	}
 
 	// Helper type to sort Regions by theirs positions
-	regionSorter []Region
+	regionSorter []text.Region
 
 	// Helper struct to sort strings
 	textSorter struct {
@@ -72,18 +72,19 @@ func (s textSorter) Less(i, j int) bool {
 	return textA < textB
 }
 
-func (c *SortLines) Run(v *View, e *Edit) error {
+//Run will execute the SortLines command
+func (c *SortLines) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	// Used as a set of int
-	sorted_rows := make(map[int]bool)
+	sortedRows := make(map[int]bool)
 
-	regions := []Region{}
+	regions := []text.Region{}
 	texts := []string{}
 	for i := 0; i < sel.Len(); i++ {
 		// Get regions containing each line.
 		for _, r := range v.Lines(sel.Get(i)) {
-			if ok := sorted_rows[r.Begin()]; !ok {
-				sorted_rows[r.Begin()] = true
+			if ok := sortedRows[r.Begin()]; !ok {
+				sortedRows[r.Begin()] = true
 				regions = append(regions, r)
 				texts = append(texts, v.Substr(r))
 			}
@@ -103,7 +104,7 @@ func (c *SortLines) Run(v *View, e *Edit) error {
 
 	offset := 0
 	for i, r := range regions {
-		r = Region{r.A + offset, r.B + offset}
+		r = text.Region{r.A + offset, r.B + offset}
 		if i < len(texts) {
 			v.Replace(e, r, texts[i])
 			offset += len(texts[i]) - r.Size()
@@ -118,9 +119,10 @@ func (c *SortLines) Run(v *View, e *Edit) error {
 	return nil
 }
 
-func (c *SortSelection) Run(v *View, e *Edit) error {
+//Run executes the sort slection command
+func (c *SortSelection) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
-	regions := make([]Region, sel.Len())
+	regions := make([]text.Region, sel.Len())
 	texts := make([]string, sel.Len())
 	for i := 0; i < sel.Len(); i++ {
 		regions[i] = sel.Get(i)
@@ -140,7 +142,7 @@ func (c *SortSelection) Run(v *View, e *Edit) error {
 
 	offset := 0
 	for i, r := range regions {
-		r = Region{r.A + offset, r.B + offset}
+		r = text.Region{r.A + offset, r.B + offset}
 		if i < len(texts) {
 			v.Replace(e, r, texts[i])
 			offset += len(texts[i]) - r.Size()
@@ -181,7 +183,7 @@ func removeDuplicates(caseSensitive bool, xs []string) []string {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&SortLines{},
 		&SortSelection{},
 	})

--- a/sort.go
+++ b/sort.go
@@ -14,7 +14,7 @@ import (
 
 type (
 	// SortLines Command sorts all lines
-	// intersecting a selection region
+	// intersecting a selection region.
 	SortLines struct {
 		backend.DefaultCommand
 		CaseSensitive    bool
@@ -24,7 +24,7 @@ type (
 
 	// SortSelection Command sorts contents
 	// of each selection region with respect to
-	// each other
+	// each other.
 	SortSelection struct {
 		backend.DefaultCommand
 		CaseSensitive    bool
@@ -32,10 +32,10 @@ type (
 		RemoveDuplicates bool
 	}
 
-	// Helper type to sort Regions by theirs positions
+	// Helper type to sort Regions by theirs positions.
 	regionSorter []text.Region
 
-	// Helper struct to sort strings
+	// Helper struct to sort strings.
 	textSorter struct {
 		texts         []string
 		caseSensitive bool
@@ -72,7 +72,7 @@ func (s textSorter) Less(i, j int) bool {
 	return textA < textB
 }
 
-// Run will execute the SortLines command
+// Run executes the SortLines command.
 func (c *SortLines) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	// Used as a set of int
@@ -119,7 +119,7 @@ func (c *SortLines) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Run executes the sort slection command
+// Run executes the sort slection command.
 func (c *SortSelection) Run(v *backend.View, e *backend.Edit) error {
 	sel := v.Sel()
 	regions := make([]text.Region, sel.Len())
@@ -155,7 +155,7 @@ func (c *SortSelection) Run(v *backend.View, e *backend.Edit) error {
 	return nil
 }
 
-// Remove duplicate ones from a sorted slice of string
+// Remove duplicate ones from a sorted slice of string.
 func removeDuplicates(caseSensitive bool, xs []string) []string {
 	var i, j int
 	for j < len(xs) {

--- a/sort_test.go
+++ b/sort_test.go
@@ -7,8 +7,8 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type sortTest struct {
@@ -16,12 +16,12 @@ type sortTest struct {
 	caseSensitive    bool
 	reverse          bool
 	removeDuplicates bool
-	sel              []Region
+	sel              []text.Region
 	expect           string
 }
 
 func runSortTest(command string, tests []sortTest, t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -41,14 +41,14 @@ func runSortTest(command string, tests []sortTest, t *testing.T) {
 			v.Sel().Add(r)
 		}
 
-		args := Args{
+		args := backend.Args{
 			"case_sensitive":    test.caseSensitive,
 			"reverse":           test.reverse,
 			"remove_duplicates": test.removeDuplicates,
 		}
 		ed.CommandHandler().RunTextCommand(v, command, args)
 
-		if d := v.Substr(Region{0, v.Size()}); d != test.expect {
+		if d := v.Substr(text.Region{0, v.Size()}); d != test.expect {
 			t.Errorf("Test %d: Excepted %#v,\n but got %#v", i, test.expect, d)
 		}
 	}
@@ -61,7 +61,7 @@ func TestSortLines(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{0, 5}},
+			[]text.Region{{0, 5}},
 			"B\na\nc",
 		},
 		{ // Case insensitive
@@ -69,7 +69,7 @@ func TestSortLines(t *testing.T) {
 			false,
 			false,
 			false,
-			[]Region{{0, 17}},
+			[]text.Region{{0, 17}},
 			"lime\nSublime\ntext",
 		},
 		{ // Reverse
@@ -77,7 +77,7 @@ func TestSortLines(t *testing.T) {
 			true,
 			true,
 			false,
-			[]Region{{0, 5}},
+			[]text.Region{{0, 5}},
 			"c\nb\na",
 		},
 		{ // Noncontinuous selection
@@ -85,7 +85,7 @@ func TestSortLines(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{0, 1}, {4, 5}},
+			[]text.Region{{0, 1}, {4, 5}},
 			"a\nc\nb",
 		},
 		{ // Noncontinuous selection, out of order
@@ -93,7 +93,7 @@ func TestSortLines(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{4, 5}, {0, 1}},
+			[]text.Region{{4, 5}, {0, 1}},
 			"a\nc\nb",
 		},
 		{ // Remove duplicates
@@ -101,7 +101,7 @@ func TestSortLines(t *testing.T) {
 			true,
 			false,
 			true,
-			[]Region{{0, 5}},
+			[]text.Region{{0, 5}},
 			"a\nb\n",
 		},
 		{ // Remove duplicates case insensitive
@@ -109,7 +109,7 @@ func TestSortLines(t *testing.T) {
 			false,
 			false,
 			true,
-			[]Region{{0, 5}},
+			[]text.Region{{0, 5}},
 			"a\nb\n",
 		},
 		{ // No duplicates removal
@@ -117,7 +117,7 @@ func TestSortLines(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{0, 8}},
+			[]text.Region{{0, 8}},
 			"a\nb\nc\nc\n",
 		},
 	}
@@ -132,7 +132,7 @@ func TestSortSelection(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{0, 1}, {1, 2}, {2, 3}},
+			[]text.Region{{0, 1}, {1, 2}, {2, 3}},
 			"Bac",
 		},
 		{ // Case insensitive
@@ -140,7 +140,7 @@ func TestSortSelection(t *testing.T) {
 			false,
 			false,
 			false,
-			[]Region{{0, 4}, {4, 11}, {11, 15}},
+			[]text.Region{{0, 4}, {4, 11}, {11, 15}},
 			"limeSublimetext",
 		},
 		{ // Reverse
@@ -148,7 +148,7 @@ func TestSortSelection(t *testing.T) {
 			true,
 			true,
 			false,
-			[]Region{{0, 1}, {1, 2}, {2, 3}},
+			[]text.Region{{0, 1}, {1, 2}, {2, 3}},
 			"cba",
 		},
 		{ // Noncontinuous selection
@@ -156,7 +156,7 @@ func TestSortSelection(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{0, 1}, {2, 3}},
+			[]text.Region{{0, 1}, {2, 3}},
 			"acb",
 		},
 		{ // Noncontinuous selection, out of order
@@ -164,7 +164,7 @@ func TestSortSelection(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{2, 3}, {0, 1}},
+			[]text.Region{{2, 3}, {0, 1}},
 			"acb",
 		},
 		{ // Remove duplicates
@@ -172,7 +172,7 @@ func TestSortSelection(t *testing.T) {
 			true,
 			false,
 			true,
-			[]Region{{0, 1}, {1, 2}, {2, 3}},
+			[]text.Region{{0, 1}, {1, 2}, {2, 3}},
 			"ab",
 		},
 		{ // Remove duplicates case insensitive
@@ -180,7 +180,7 @@ func TestSortSelection(t *testing.T) {
 			false,
 			false,
 			true,
-			[]Region{{0, 1}, {1, 2}, {2, 3}},
+			[]text.Region{{0, 1}, {1, 2}, {2, 3}},
 			"ab",
 		},
 		{ // No duplicates removal
@@ -188,7 +188,7 @@ func TestSortSelection(t *testing.T) {
 			true,
 			false,
 			false,
-			[]Region{{0, 1}, {1, 2}, {2, 3}, {3, 4}},
+			[]text.Region{{0, 1}, {1, 2}, {2, 3}, {3, 4}},
 			"abcc",
 		},
 	}

--- a/testdata/save_test.txt
+++ b/testdata/save_test.txt
@@ -1,1 +1,1 @@
-Some Text
+Before text

--- a/testdata/save_test.txt
+++ b/testdata/save_test.txt
@@ -1,1 +1,1 @@
-Before text
+Some Text

--- a/transpose.go
+++ b/transpose.go
@@ -17,7 +17,7 @@ type (
 	}
 )
 
-//Run will execute the transpose command
+// Run will execute the transpose command
 func (c *Transpose) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of Transpose:

--- a/transpose.go
+++ b/transpose.go
@@ -17,7 +17,7 @@ type (
 	}
 )
 
-// Run will execute the transpose command
+// Run executes the transpose command.
 func (c *Transpose) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of Transpose:

--- a/transpose.go
+++ b/transpose.go
@@ -5,19 +5,20 @@
 package commands
 
 import (
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 type (
-	// Transpose: Swap the characters on either side of the cursor,
+	// Transpose will Swap the characters on either side of the cursor,
 	// then move the cursor forward one character.
 	Transpose struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *Transpose) Run(v *View, e *Edit) error {
+//Run will execute the transpose command
+func (c *Transpose) Run(v *backend.View, e *backend.Edit) error {
 	/*
 		Correct behavior of Transpose:
 			- ...is actually surprisingly complicated.
@@ -34,12 +35,12 @@ func (c *Transpose) Run(v *View, e *Edit) error {
 			- See transpose_test.go for examples.
 	*/
 
-	rsnew := RegionSet{}
+	rsnew := text.RegionSet{}
 	rs := v.Sel().Regions()
 
 	if v.Sel().HasNonEmpty() {
 		// Build a list of transpose regions based on the current selected regions
-		trs := RegionSet{}
+		trs := text.RegionSet{}
 		for _, r := range rs {
 			if r.Empty() {
 				trs.Add(v.Word(r.A))
@@ -60,7 +61,7 @@ func (c *Transpose) Run(v *View, e *Edit) error {
 			dlen := r.Size()
 			v.Replace(e, r, stxt)
 			trs.Adjust(r.Begin()+1, slen-dlen)
-			rsnew.Add(Region{r.Begin(), r.Begin() + slen})
+			rsnew.Add(text.Region{r.Begin(), r.Begin() + slen})
 			stxt, slen = dtxt, dlen
 		}
 
@@ -69,12 +70,12 @@ func (c *Transpose) Run(v *View, e *Edit) error {
 			if i > 0 && r.A-1 == v.Sel().Regions()[i-1].A {
 				continue
 			}
-			rsnew.Add(Region{r.A + 1, r.B + 1})
+			rsnew.Add(text.Region{r.A + 1, r.B + 1})
 			if r.A == 0 || r.A >= v.Size() {
 				continue
 			}
-			r1 := Region{r.A - 1, r.A}
-			r2 := Region{r.A, r.A + 1}
+			r1 := text.Region{r.A - 1, r.A}
+			r2 := text.Region{r.A, r.A + 1}
 			s1 := v.Substr(r1)
 			s2 := v.Substr(r2)
 			v.Replace(e, r1, s2)
@@ -85,14 +86,14 @@ func (c *Transpose) Run(v *View, e *Edit) error {
 	// Rebuild the active selections
 	v.Sel().Clear()
 	for _, r := range rsnew.Regions() {
-		v.Sel().Add(Region{r.A, r.B})
+		v.Sel().Add(text.Region{r.A, r.B})
 	}
 
 	return nil
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Transpose{},
 	})
 }

--- a/transpose_test.go
+++ b/transpose_test.go
@@ -7,12 +7,12 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 func TestTranspose(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 
 	w := ed.NewWindow()
 	defer w.Close()
@@ -25,9 +25,9 @@ func TestTranspose(t *testing.T) {
 
 	type Test struct {
 		start      string
-		regions    []Region
+		regions    []text.Region
 		expect     string
-		newregions []Region
+		newregions []text.Region
 	}
 
 	// Test results produced using ST3, and s like:
@@ -38,46 +38,46 @@ func TestTranspose(t *testing.T) {
 		{
 			// Simple test with just one cursor position
 			"one",
-			[]Region{{1, 1}},
+			[]text.Region{{1, 1}},
 			"noe",
-			[]Region{{2, 2}},
+			[]text.Region{{2, 2}},
 		},
 		{
 			// Test with several cursors, including one at the beginning of
 			// the buffer, which doesn't transpose, and one beyond the end.
 			"one two three four",
-			[]Region{{0, 0}, {2, 2}, {5, 5}, {20, 20}},
+			[]text.Region{{0, 0}, {2, 2}, {5, 5}, {20, 20}},
 			"oen wto three four",
-			[]Region{{1, 1}, {3, 3}, {6, 6}, {21, 21}},
+			[]text.Region{{1, 1}, {3, 3}, {6, 6}, {21, 21}},
 		},
 		{
 			// Similar test, but with two adjacent cursors. The second one gets
 			// dropped, and doesn't transpose.
 			"one two three four",
-			[]Region{{0, 0}, {1, 1}, {5, 5}},
+			[]text.Region{{0, 0}, {1, 1}, {5, 5}},
 			"one wto three four",
-			[]Region{{1, 1}, {6, 6}},
+			[]text.Region{{1, 1}, {6, 6}},
 		},
 		{
 			// Test with a single region. This should do nothing.
 			"one two three four",
-			[]Region{{6, 10}},
+			[]text.Region{{6, 10}},
 			"one two three four",
-			[]Region{{6, 10}},
+			[]text.Region{{6, 10}},
 		},
 		{
 			// Test with two regions of different sizes
 			"one two three four",
-			[]Region{{4, 7}, {8, 13}},
+			[]text.Region{{4, 7}, {8, 13}},
 			"one three two four",
-			[]Region{{4, 9}, {10, 13}},
+			[]text.Region{{4, 9}, {10, 13}},
 		},
 		{
 			// Test with four regions
 			"one two three four",
-			[]Region{{0, 3}, {4, 7}, {8, 13}, {14, 18}},
+			[]text.Region{{0, 3}, {4, 7}, {8, 13}, {14, 18}},
 			"four one two three",
-			[]Region{{0, 4}, {5, 8}, {9, 12}, {13, 18}},
+			[]text.Region{{0, 4}, {5, 8}, {9, 12}, {13, 18}},
 		},
 		{
 			// Test with one region and three cursors. The newline at the end
@@ -85,23 +85,23 @@ func TestTranspose(t *testing.T) {
 			// call, which currently has problems if it finds EOF at the end
 			// of the word.
 			"one two three four\n",
-			[]Region{{0, 0}, {4, 7}, {9, 9}, {16, 16}},
+			[]text.Region{{0, 0}, {4, 7}, {9, 9}, {16, 16}},
 			"four one two three\n",
-			[]Region{{0, 4}, {5, 8}, {9, 12}, {13, 18}},
+			[]text.Region{{0, 4}, {5, 8}, {9, 12}, {13, 18}},
 		},
 		{
 			// Test with two regions and two cursors
 			"one two three four",
-			[]Region{{0, 0}, {4, 7}, {9, 9}, {15, 16}},
+			[]text.Region{{0, 0}, {4, 7}, {9, 9}, {15, 16}},
 			"o one two fthreeur",
-			[]Region{{0, 1}, {2, 5}, {6, 9}, {11, 16}},
+			[]text.Region{{0, 1}, {2, 5}, {6, 9}, {11, 16}},
 		},
 	}
 
 	for i, test := range tests {
 		// Load the starting text into the buffer
 		e := v.BeginEdit()
-		v.Erase(e, Region{0, v.Size()})
+		v.Erase(e, text.Region{0, v.Size()})
 		v.Insert(e, 0, test.start)
 		v.EndEdit(e)
 
@@ -113,7 +113,7 @@ func TestTranspose(t *testing.T) {
 
 		ed.CommandHandler().RunTextCommand(v, "transpose", nil)
 
-		b := v.Substr(Region{0, v.Size()})
+		b := v.Substr(text.Region{0, v.Size()})
 		if b != test.expect {
 			t.Errorf("Test %d: Expected %q; got %q", i, test.expect, b)
 		}

--- a/undoredo.go
+++ b/undoredo.go
@@ -1,5 +1,5 @@
-// Copyright 2013 The lime Authors.
-// Use of this source code is governed by a 2-clause
+//  Copyright 2013 The lime Authors.
+//  Use of this source code is governed by a 2-clause
 // BSD-style license that can be found in the LICENSE file.
 
 package commands
@@ -10,26 +10,26 @@ import (
 
 type (
 
-	//Undo command will revert the last change
+	// Undo command will revert the last change
 	Undo struct {
 		backend.BypassUndoCommand
 		hard bool
 	}
 
-	//Redo command will redo the last chnage
+	// Redo command will redo the last chnage
 	Redo struct {
 		backend.BypassUndoCommand
 		hard bool
 	}
 )
 
-//Run will execute the Undo command
+// Run will execute the Undo command
 func (c *Undo) Run(v *backend.View, e *backend.Edit) error {
 	v.UndoStack().Undo(c.hard)
 	return nil
 }
 
-//Run will execute the Redo command
+// Run will execute the Redo command
 func (c *Redo) Run(v *backend.View, e *backend.Edit) error {
 	v.UndoStack().Redo(c.hard)
 	return nil

--- a/undoredo.go
+++ b/undoredo.go
@@ -10,26 +10,26 @@ import (
 
 type (
 
-	// Undo command will revert the last change
+	// Undo command will revert the last change.
 	Undo struct {
 		backend.BypassUndoCommand
 		hard bool
 	}
 
-	// Redo command will redo the last chnage
+	// Redo command will redo the last chnage.
 	Redo struct {
 		backend.BypassUndoCommand
 		hard bool
 	}
 )
 
-// Run will execute the Undo command
+// Run executes the Undo command.
 func (c *Undo) Run(v *backend.View, e *backend.Edit) error {
 	v.UndoStack().Undo(c.hard)
 	return nil
 }
 
-// Run will execute the Redo command
+// Run executes the Redo command.
 func (c *Redo) Run(v *backend.View, e *backend.Edit) error {
 	v.UndoStack().Redo(c.hard)
 	return nil

--- a/undoredo.go
+++ b/undoredo.go
@@ -10,13 +10,11 @@ import (
 
 type (
 
-	// Undo command will revert the last change.
 	Undo struct {
 		backend.BypassUndoCommand
 		hard bool
 	}
 
-	// Redo command will redo the last chnage.
 	Redo struct {
 		backend.BypassUndoCommand
 		hard bool

--- a/undoredo.go
+++ b/undoredo.go
@@ -1,5 +1,5 @@
-//  Copyright 2013 The lime Authors.
-//  Use of this source code is governed by a 2-clause
+// Copyright 2013 The lime Authors.
+// Use of this source code is governed by a 2-clause
 // BSD-style license that can be found in the LICENSE file.
 
 package commands

--- a/undoredo.go
+++ b/undoredo.go
@@ -9,7 +9,6 @@ import (
 )
 
 type (
-
 	Undo struct {
 		backend.BypassUndoCommand
 		hard bool

--- a/undoredo.go
+++ b/undoredo.go
@@ -5,32 +5,38 @@
 package commands
 
 import (
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
+
+	//Undo command will revert the last change
 	Undo struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 		hard bool
 	}
+
+	//Redo command will redo the last chnage
 	Redo struct {
-		BypassUndoCommand
+		backend.BypassUndoCommand
 		hard bool
 	}
 )
 
-func (c *Undo) Run(v *View, e *Edit) error {
+//Run will execute the Undo command
+func (c *Undo) Run(v *backend.View, e *backend.Edit) error {
 	v.UndoStack().Undo(c.hard)
 	return nil
 }
 
-func (c *Redo) Run(v *View, e *Edit) error {
+//Run will execute the Redo command
+func (c *Redo) Run(v *backend.View, e *backend.Edit) error {
 	v.UndoStack().Redo(c.hard)
 	return nil
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Undo{hard: true},
 		&Redo{hard: true},
 	})

--- a/undoredo_test.go
+++ b/undoredo_test.go
@@ -7,12 +7,12 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
-	. "github.com/limetext/text"
+	"github.com/limetext/backend"
+	"github.com/limetext/text"
 )
 
 func TestUndoRedos(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ch := ed.CommandHandler()
 	w := ed.NewWindow()
 	defer w.Close()
@@ -27,7 +27,7 @@ func TestUndoRedos(t *testing.T) {
 	v.Insert(edit, 0, "abcd")
 	v.EndEdit(edit)
 	v.Sel().Clear()
-	r := []Region{
+	r := []text.Region{
 		{0, 0},
 		{1, 1},
 		{2, 2},
@@ -45,20 +45,20 @@ func TestUndoRedos(t *testing.T) {
 	}
 	v.EndEdit(edit)
 
-	if v.Substr(Region{0, v.Size()}) != "1234a1234b1234c1234d" {
-		t.Error(v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "1234a1234b1234c1234d" {
+		t.Error(v.Substr(text.Region{0, v.Size()}))
 	}
 	ch.RunTextCommand(v, "undo", nil)
-	if v.Substr(Region{0, v.Size()}) != "abcd" {
-		t.Error("expected 'abcd', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "abcd" {
+		t.Error("expected 'abcd', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 	ch.RunTextCommand(v, "redo", nil)
-	if v.Substr(Region{0, v.Size()}) != "1234a1234b1234c1234d" {
-		t.Error("expected '1234a1234b1234c1234d', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "1234a1234b1234c1234d" {
+		t.Error("expected '1234a1234b1234c1234d', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 
 	v.Sel().Clear()
-	r = []Region{
+	r = []text.Region{
 		{0, 0},
 		{5, 5},
 		{10, 10},
@@ -76,34 +76,34 @@ func TestUndoRedos(t *testing.T) {
 	}
 	v.EndEdit(edit)
 
-	if v.Substr(Region{0, v.Size()}) != "hello world1234ahello world1234bhello world1234chello world1234d" {
-		t.Error(v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "hello world1234ahello world1234bhello world1234chello world1234d" {
+		t.Error(v.Substr(text.Region{0, v.Size()}))
 	}
 	ch.RunTextCommand(v, "undo", nil)
 
-	if v.Substr(Region{0, v.Size()}) != "1234a1234b1234c1234d" {
-		t.Error("expected '1234a1234b1234c1234d', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "1234a1234b1234c1234d" {
+		t.Error("expected '1234a1234b1234c1234d', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 	ch.RunTextCommand(v, "undo", nil)
-	if v.Substr(Region{0, v.Size()}) != "abcd" {
-		t.Error("expected 'abcd', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "abcd" {
+		t.Error("expected 'abcd', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 	ch.RunTextCommand(v, "undo", nil)
-	if v.Substr(Region{0, v.Size()}) != "" {
-		t.Error("expected '', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "" {
+		t.Error("expected '', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 	v.UndoStack().Redo(true)
-	if v.Substr(Region{0, v.Size()}) != "abcd" {
-		t.Error("expected 'abcd', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "abcd" {
+		t.Error("expected 'abcd', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 
 	v.UndoStack().Redo(true)
-	if v.Substr(Region{0, v.Size()}) != "1234a1234b1234c1234d" {
-		t.Error("expected '1234a1234b1234c1234d', but got: ", v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "1234a1234b1234c1234d" {
+		t.Error("expected '1234a1234b1234c1234d', but got: ", v.Substr(text.Region{0, v.Size()}))
 	}
 
 	v.UndoStack().Redo(true)
-	if v.Substr(Region{0, v.Size()}) != "hello world1234ahello world1234bhello world1234chello world1234d" {
-		t.Error(v.Substr(Region{0, v.Size()}))
+	if v.Substr(text.Region{0, v.Size()}) != "hello world1234ahello world1234bhello world1234chello world1234d" {
+		t.Error(v.Substr(text.Region{0, v.Size()}))
 	}
 }

--- a/view.go
+++ b/view.go
@@ -4,28 +4,36 @@
 
 package commands
 
-import . "github.com/limetext/backend"
+import "github.com/limetext/backend"
 
 type (
+	//Close command will close the currently opened view
 	Close struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//NextView command will switch to the view which is
+	//immediately to the next of the current view
 	NextView struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//PrevView command will switch to the view
+	//which is immediately before hte current view
 	PrevView struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//SetFileType command will let us set the file type
+	//for the currently active view, eg: for Syntax highlighting
 	SetFileType struct {
-		DefaultCommand
+		backend.DefaultCommand
 		Syntax string
 	}
 )
 
-func (c *Close) Run(w *Window) error {
+//Run will execute the Close command
+func (c *Close) Run(w *backend.Window) error {
 	if v := w.ActiveView(); v != nil {
 		v.Close()
 	} else {
@@ -34,7 +42,8 @@ func (c *Close) Run(w *Window) error {
 	return nil
 }
 
-func (c *NextView) Run(w *Window) error {
+//Run wll execute the NextView command
+func (c *NextView) Run(w *backend.Window) error {
 	for i, v := range w.Views() {
 		if v == w.ActiveView() {
 			i++
@@ -49,7 +58,8 @@ func (c *NextView) Run(w *Window) error {
 	return nil
 }
 
-func (c *PrevView) Run(w *Window) error {
+//Run will execute the PrevView command
+func (c *PrevView) Run(w *backend.Window) error {
 	for i, v := range w.Views() {
 		if v == w.ActiveView() {
 			if i == 0 {
@@ -64,13 +74,14 @@ func (c *PrevView) Run(w *Window) error {
 	return nil
 }
 
-func (c *SetFileType) Run(v *View, e *Edit) error {
+//Run will execute the SetFileType command
+func (c *SetFileType) Run(v *backend.View, e *backend.Edit) error {
 	v.SetSyntaxFile(c.Syntax)
 	return nil
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&Close{},
 		&NextView{},
 		&PrevView{},

--- a/view.go
+++ b/view.go
@@ -7,32 +7,32 @@ package commands
 import "github.com/limetext/backend"
 
 type (
-	// Close command will close the currently opened view
+	// Close command closes the currently opened view.
 	Close struct {
 		backend.DefaultCommand
 	}
 
-	// NextView command will switch to the view which is
-	// immediately to the next of the current view
+	// NextView command switches to the view which is
+	// immediately to the next of the current view.
 	NextView struct {
 		backend.DefaultCommand
 	}
 
-	// PrevView command will switch to the view
-	// which is immediately before hte current view
+	// PrevView command switches to the view
+	// which is immediately before hte current view.
 	PrevView struct {
 		backend.DefaultCommand
 	}
 
 	// SetFileType command will let us set the file type
-	// for the currently active view, eg: for Syntax highlighting
+	// for the currently active view, eg: for Syntax highlighting.
 	SetFileType struct {
 		backend.DefaultCommand
 		Syntax string
 	}
 )
 
-// Run will execute the Close command
+// Run executes the Close command.
 func (c *Close) Run(w *backend.Window) error {
 	if v := w.ActiveView(); v != nil {
 		v.Close()
@@ -42,7 +42,7 @@ func (c *Close) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run wll execute the NextView command
+// Run executes the NextView command.
 func (c *NextView) Run(w *backend.Window) error {
 	for i, v := range w.Views() {
 		if v == w.ActiveView() {
@@ -58,7 +58,7 @@ func (c *NextView) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run will execute the PrevView command
+// Run executes the PrevView command.
 func (c *PrevView) Run(w *backend.Window) error {
 	for i, v := range w.Views() {
 		if v == w.ActiveView() {
@@ -74,7 +74,7 @@ func (c *PrevView) Run(w *backend.Window) error {
 	return nil
 }
 
-// Run will execute the SetFileType command
+// Run executes the SetFileType command.
 func (c *SetFileType) Run(v *backend.View, e *backend.Edit) error {
 	v.SetSyntaxFile(c.Syntax)
 	return nil

--- a/view.go
+++ b/view.go
@@ -7,32 +7,32 @@ package commands
 import "github.com/limetext/backend"
 
 type (
-	//Close command will close the currently opened view
+	// Close command will close the currently opened view
 	Close struct {
 		backend.DefaultCommand
 	}
 
-	//NextView command will switch to the view which is
-	//immediately to the next of the current view
+	// NextView command will switch to the view which is
+	// immediately to the next of the current view
 	NextView struct {
 		backend.DefaultCommand
 	}
 
-	//PrevView command will switch to the view
-	//which is immediately before hte current view
+	// PrevView command will switch to the view
+	// which is immediately before hte current view
 	PrevView struct {
 		backend.DefaultCommand
 	}
 
-	//SetFileType command will let us set the file type
-	//for the currently active view, eg: for Syntax highlighting
+	// SetFileType command will let us set the file type
+	// for the currently active view, eg: for Syntax highlighting
 	SetFileType struct {
 		backend.DefaultCommand
 		Syntax string
 	}
 )
 
-//Run will execute the Close command
+// Run will execute the Close command
 func (c *Close) Run(w *backend.Window) error {
 	if v := w.ActiveView(); v != nil {
 		v.Close()
@@ -42,7 +42,7 @@ func (c *Close) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run wll execute the NextView command
+// Run wll execute the NextView command
 func (c *NextView) Run(w *backend.Window) error {
 	for i, v := range w.Views() {
 		if v == w.ActiveView() {
@@ -58,7 +58,7 @@ func (c *NextView) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run will execute the PrevView command
+// Run will execute the PrevView command
 func (c *PrevView) Run(w *backend.Window) error {
 	for i, v := range w.Views() {
 		if v == w.ActiveView() {
@@ -74,7 +74,7 @@ func (c *PrevView) Run(w *backend.Window) error {
 	return nil
 }
 
-//Run will execute the SetFileType command
+// Run will execute the SetFileType command
 func (c *SetFileType) Run(v *backend.View, e *backend.Edit) error {
 	v.SetSyntaxFile(c.Syntax)
 	return nil

--- a/view_test.go
+++ b/view_test.go
@@ -7,11 +7,11 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 func TestClose(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 
 	l := len(ed.Windows())
 	w := ed.NewWindow()
@@ -36,7 +36,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestNextView(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 
@@ -84,7 +84,7 @@ func TestNextView(t *testing.T) {
 }
 
 func TestPrevView(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	defer w.Close()
 

--- a/window.go
+++ b/window.go
@@ -9,64 +9,64 @@ import (
 )
 
 type (
-	//NewWindow command lets us open a new window
-	//of lime editor
+	// NewWindow command lets us open a new window
+	// of lime editor
 	NewWindow struct {
 		backend.DefaultCommand
 	}
 
-	//CloseAll command lets us close all the
-	//open views inside the current window
+	// CloseAll command lets us close all the
+	// open views inside the current window
 	CloseAll struct {
 		backend.DefaultCommand
 	}
 
-	//CloseWindow command lets us close the current window
+	// CloseWindow command lets us close the current window
 	CloseWindow struct {
 		backend.DefaultCommand
 	}
 
-	//NewWindowApp will create a new window and open an
-	//empty editor and set it as active
+	// NewWindowApp will create a new window and open an
+	// empty editor and set it as active
 	NewWindowApp struct {
 		backend.DefaultCommand
 	}
 
-	//CloseWindowApp command will close the windows
-	//which are active
+	// CloseWindowApp command will close the windows
+	// which are active
 	CloseWindowApp struct {
 		backend.DefaultCommand
 	}
 )
 
-//Run executes the NewWindow command
+// Run executes the NewWindow command
 func (c *NewWindow) Run(w *backend.Window) error {
 	ed := backend.GetEditor()
 	ed.SetActiveWindow(ed.NewWindow())
 	return nil
 }
 
-//Run executes the CloseAll command
+// Run executes the CloseAll command
 func (c *CloseAll) Run(w *backend.Window) error {
 	w.CloseAllViews()
 	return nil
 }
 
-//Run executes the CloseWindow command
+// Run executes the CloseWindow command
 func (c *CloseWindow) Run(w *backend.Window) error {
 	ed := backend.GetEditor()
 	ed.ActiveWindow().Close()
 	return nil
 }
 
-//Run executes the NewWindowApp command
+// Run executes the NewWindowApp command
 func (c *NewWindowApp) Run() error {
 	ed := backend.GetEditor()
 	ed.SetActiveWindow(ed.NewWindow())
 	return nil
 }
 
-//Run executes the CloseWindowApp command
+// Run executes the CloseWindowApp command
 func (c *CloseWindowApp) Run() error {
 	ed := backend.GetEditor()
 	ed.ActiveWindow().Close()

--- a/window.go
+++ b/window.go
@@ -9,74 +9,75 @@ import (
 )
 
 type (
-	// NewWindow command lets us open a new window
-	// of lime editor
+	// NewWindow command opens a new window.
 	NewWindow struct {
 		backend.DefaultCommand
 	}
 
-	// CloseAll command lets us close all the
-	// open views inside the current window
+	// CloseAll command closes all the
+	// open views inside the current window.
 	CloseAll struct {
 		backend.DefaultCommand
 	}
 
-	// CloseWindow command lets us close the current window
+	// CloseWindow command lets us close the current window.
 	CloseWindow struct {
 		backend.DefaultCommand
 	}
 
-	// NewWindowApp will create a new window and open an
-	// empty editor and set it as active
+	// NewWindowApp creates a new window, setting it as active.
 	NewWindowApp struct {
 		backend.DefaultCommand
 	}
 
-	// CloseWindowApp command will close the windows
-	// which are active
+	// CloseWindowApp command closes all the active windows.
 	CloseWindowApp struct {
 		backend.DefaultCommand
 	}
 )
 
-// Run executes the NewWindow command
+// Run executes the NewWindow command.
 func (c *NewWindow) Run(w *backend.Window) error {
 	ed := backend.GetEditor()
 	ed.SetActiveWindow(ed.NewWindow())
 	return nil
 }
 
-// Run executes the CloseAll command
+// Run executes the CloseAll command.
 func (c *CloseAll) Run(w *backend.Window) error {
 	w.CloseAllViews()
 	return nil
 }
 
-// Run executes the CloseWindow command
+// Run executes the CloseWindow command.
 func (c *CloseWindow) Run(w *backend.Window) error {
 	ed := backend.GetEditor()
 	ed.ActiveWindow().Close()
 	return nil
 }
 
-// Run executes the NewWindowApp command
+// Run executes the NewWindowApp command.
 func (c *NewWindowApp) Run() error {
 	ed := backend.GetEditor()
 	ed.SetActiveWindow(ed.NewWindow())
 	return nil
 }
 
-// Run executes the CloseWindowApp command
+// Run executes the CloseWindowApp command.
 func (c *CloseWindowApp) Run() error {
 	ed := backend.GetEditor()
 	ed.ActiveWindow().Close()
 	return nil
 }
 
+// IsChecked shows if NewWindowApp has a
+// checkbox in the frontend.
 func (c *NewWindowApp) IsChecked() bool {
 	return false
 }
 
+// IsChecked shows if CloseWindowApp has a
+// checkbox in the frontend.
 func (c *CloseWindowApp) IsChecked() bool {
 	return false
 }

--- a/window.go
+++ b/window.go
@@ -5,56 +5,70 @@
 package commands
 
 import (
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 type (
+	//NewWindow command lets us open a new window
+	//of lime editor
 	NewWindow struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//CloseAll command lets us close all the
+	//open views inside the current window
 	CloseAll struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//CloseWindow command lets us close the current window
 	CloseWindow struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//NewWindowApp will create a new window and open an
+	//empty editor and set it as active
 	NewWindowApp struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 
+	//CloseWindowApp command will close the windows
+	//which are active
 	CloseWindowApp struct {
-		DefaultCommand
+		backend.DefaultCommand
 	}
 )
 
-func (c *NewWindow) Run(w *Window) error {
-	ed := GetEditor()
+//Run executes the NewWindow command
+func (c *NewWindow) Run(w *backend.Window) error {
+	ed := backend.GetEditor()
 	ed.SetActiveWindow(ed.NewWindow())
 	return nil
 }
 
-func (c *CloseAll) Run(w *Window) error {
+//Run executes the CloseAll command
+func (c *CloseAll) Run(w *backend.Window) error {
 	w.CloseAllViews()
 	return nil
 }
 
-func (c *CloseWindow) Run(w *Window) error {
-	ed := GetEditor()
+//Run executes the CloseWindow command
+func (c *CloseWindow) Run(w *backend.Window) error {
+	ed := backend.GetEditor()
 	ed.ActiveWindow().Close()
 	return nil
 }
 
+//Run executes the NewWindowApp command
 func (c *NewWindowApp) Run() error {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.SetActiveWindow(ed.NewWindow())
 	return nil
 }
 
+//Run executes the CloseWindowApp command
 func (c *CloseWindowApp) Run() error {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	ed.ActiveWindow().Close()
 	return nil
 }
@@ -68,7 +82,7 @@ func (c *CloseWindowApp) IsChecked() bool {
 }
 
 func init() {
-	register([]Command{
+	register([]backend.Command{
 		&NewWindow{},
 		&CloseAll{},
 		&CloseWindow{},

--- a/window_test.go
+++ b/window_test.go
@@ -7,11 +7,11 @@ package commands
 import (
 	"testing"
 
-	. "github.com/limetext/backend"
+	"github.com/limetext/backend"
 )
 
 func TestNewWindow(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	l := len(ed.Windows())
 	ed.CommandHandler().RunWindowCommand(ed.ActiveWindow(), "new_window", nil)
 
@@ -21,7 +21,7 @@ func TestNewWindow(t *testing.T) {
 }
 
 func TestCloseAll(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 
 	w := ed.NewWindow()
 	defer w.Close()
@@ -38,7 +38,7 @@ func TestCloseAll(t *testing.T) {
 }
 
 func TestCloseWindow(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	w := ed.NewWindow()
 	l := len(ed.Windows())
 	ed.CommandHandler().RunWindowCommand(w, "close_window", nil)
@@ -49,7 +49,7 @@ func TestCloseWindow(t *testing.T) {
 }
 
 func TestNewAppWindow(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	l := len(ed.Windows())
 	ed.CommandHandler().RunApplicationCommand("new_window", nil)
 
@@ -59,7 +59,7 @@ func TestNewAppWindow(t *testing.T) {
 }
 
 func TestCloseAppWindow(t *testing.T) {
-	ed := GetEditor()
+	ed := backend.GetEditor()
 	_ = ed.NewWindow()
 	l := len(ed.Windows())
 	ed.CommandHandler().RunApplicationCommand("close_window", nil)


### PR DESCRIPTION
Comments have been changed to follow this

```
//TypeCommand does this and that
TypeCommand
```

rather than 
`//the TypeCommand is a command which does this and that`

variable names should be in CamelCase.

Added comments wherever necessary
